### PR TITLE
Add initial proposal to support hcl + yaml as configuration files

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -37,6 +38,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/tlspolicy"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -57,72 +59,73 @@ const (
 
 // Config contains all available configurables, arranged by section
 type Config struct {
-	Agent              *agentConfig           `hcl:"agent"`
-	Plugins            ast.Node               `hcl:"plugins"`
-	Telemetry          telemetry.FileConfig   `hcl:"telemetry"`
-	HealthChecks       health.Config          `hcl:"health_checks"`
+	Agent              *agentConfig           `hcl:"agent"        yaml:"agent"`
+	Plugins            ast.Node               `hcl:"plugins"      yaml:"-"    json:"-"`
+	PluginsRaw         json.RawMessage        `yaml:"plugins"     json:"plugins"`
+	Telemetry          telemetry.FileConfig   `hcl:"telemetry"    yaml:"telemetry"`
+	HealthChecks       health.Config          `hcl:"health_checks" yaml:"healthChecks"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type agentConfig struct {
-	DataDir                       string    `hcl:"data_dir"`
-	AdminSocketPath               string    `hcl:"admin_socket_path"`
-	InsecureBootstrap             bool      `hcl:"insecure_bootstrap"`
-	RebootstrapMode               string    `hcl:"rebootstrap_mode"`
-	RebootstrapDelay              string    `hcl:"rebootstrap_delay"`
-	JoinToken                     string    `hcl:"join_token"`
-	JoinTokenFile                 string    `hcl:"join_token_file"`
-	LogFile                       string    `hcl:"log_file"`
-	LogFormat                     string    `hcl:"log_format"`
-	LogLevel                      string    `hcl:"log_level"`
-	LogSourceLocation             bool      `hcl:"log_source_location"`
-	SDS                           sdsConfig `hcl:"sds"`
-	ServerAddress                 string    `hcl:"server_address"`
-	ServerPort                    int       `hcl:"server_port"`
-	SocketPath                    string    `hcl:"socket_path"`
-	WorkloadX509SVIDKeyType       string    `hcl:"workload_x509_svid_key_type"`
-	TrustBundleFormat             string    `hcl:"trust_bundle_format"`
-	TrustBundlePath               string    `hcl:"trust_bundle_path"`
-	TrustBundleUnixSocket         string    `hcl:"trust_bundle_unix_socket"`
-	TrustBundleURL                string    `hcl:"trust_bundle_url"`
-	TrustDomain                   string    `hcl:"trust_domain"`
-	AllowUnauthenticatedVerifiers bool      `hcl:"allow_unauthenticated_verifiers"`
-	AllowedForeignJWTClaims       []string  `hcl:"allowed_foreign_jwt_claims"`
-	AvailabilityTarget            string    `hcl:"availability_target"`
-	X509SVIDCacheMaxSize          int       `hcl:"x509_svid_cache_max_size"`
-	JWTSVIDCacheMaxSize           int       `hcl:"jwt_svid_cache_max_size"`
+	DataDir                       string    `hcl:"data_dir"                        yaml:"dataDir"`
+	AdminSocketPath               string    `hcl:"admin_socket_path"               yaml:"adminSocketPath"`
+	InsecureBootstrap             bool      `hcl:"insecure_bootstrap"              yaml:"insecureBootstrap"`
+	RebootstrapMode               string    `hcl:"rebootstrap_mode"                yaml:"rebootstrapMode"`
+	RebootstrapDelay              string    `hcl:"rebootstrap_delay"               yaml:"rebootstrapDelay"`
+	JoinToken                     string    `hcl:"join_token"                      yaml:"joinToken"`
+	JoinTokenFile                 string    `hcl:"join_token_file"                 yaml:"joinTokenFile"`
+	LogFile                       string    `hcl:"log_file"                        yaml:"logFile"`
+	LogFormat                     string    `hcl:"log_format"                      yaml:"logFormat"`
+	LogLevel                      string    `hcl:"log_level"                       yaml:"logLevel"`
+	LogSourceLocation             bool      `hcl:"log_source_location"             yaml:"logSourceLocation"`
+	SDS                           sdsConfig `hcl:"sds"                             yaml:"sds"`
+	ServerAddress                 string    `hcl:"server_address"                  yaml:"serverAddress"`
+	ServerPort                    int       `hcl:"server_port"                     yaml:"serverPort"`
+	SocketPath                    string    `hcl:"socket_path"                     yaml:"socketPath"`
+	WorkloadX509SVIDKeyType       string    `hcl:"workload_x509_svid_key_type"     yaml:"workloadX509SvidKeyType"`
+	TrustBundleFormat             string    `hcl:"trust_bundle_format"             yaml:"trustBundleFormat"`
+	TrustBundlePath               string    `hcl:"trust_bundle_path"               yaml:"trustBundlePath"`
+	TrustBundleUnixSocket         string    `hcl:"trust_bundle_unix_socket"        yaml:"trustBundleUnixSocket"`
+	TrustBundleURL                string    `hcl:"trust_bundle_url"                yaml:"trustBundleUrl"`
+	TrustDomain                   string    `hcl:"trust_domain"                    yaml:"trustDomain"`
+	AllowUnauthenticatedVerifiers bool      `hcl:"allow_unauthenticated_verifiers" yaml:"allowUnauthenticatedVerifiers"`
+	AllowedForeignJWTClaims       []string  `hcl:"allowed_foreign_jwt_claims"      yaml:"allowedForeignJwtClaims"`
+	AvailabilityTarget            string    `hcl:"availability_target"             yaml:"availabilityTarget"`
+	X509SVIDCacheMaxSize          int       `hcl:"x509_svid_cache_max_size"        yaml:"x509SvidCacheMaxSize"`
+	JWTSVIDCacheMaxSize           int       `hcl:"jwt_svid_cache_max_size"         yaml:"jwtSvidCacheMaxSize"`
 
-	AuthorizedDelegates []string `hcl:"authorized_delegates"`
+	AuthorizedDelegates []string `hcl:"authorized_delegates" yaml:"authorizedDelegates"`
 
 	ConfigPath string
 	ExpandEnv  bool
 
 	// Undocumented configurables
-	ProfilingEnabled bool               `hcl:"profiling_enabled"`
-	ProfilingPort    int                `hcl:"profiling_port"`
-	ProfilingFreq    int                `hcl:"profiling_freq"`
-	ProfilingNames   []string           `hcl:"profiling_names"`
-	Experimental     experimentalConfig `hcl:"experimental"`
+	ProfilingEnabled bool               `hcl:"profiling_enabled" yaml:"profilingEnabled"`
+	ProfilingPort    int                `hcl:"profiling_port"    yaml:"profilingPort"`
+	ProfilingFreq    int                `hcl:"profiling_freq"    yaml:"profilingFreq"`
+	ProfilingNames   []string           `hcl:"profiling_names"   yaml:"profilingNames"`
+	Experimental     experimentalConfig `hcl:"experimental"      yaml:"experimental"`
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type sdsConfig struct {
-	DefaultSVIDName             string `hcl:"default_svid_name"`
-	DefaultBundleName           string `hcl:"default_bundle_name"`
-	DefaultAllBundlesName       string `hcl:"default_all_bundles_name"`
-	DisableSPIFFECertValidation bool   `hcl:"disable_spiffe_cert_validation"`
+	DefaultSVIDName             string `hcl:"default_svid_name"              yaml:"defaultSvidName"`
+	DefaultBundleName           string `hcl:"default_bundle_name"            yaml:"defaultBundleName"`
+	DefaultAllBundlesName       string `hcl:"default_all_bundles_name"       yaml:"defaultAllBundlesName"`
+	DisableSPIFFECertValidation bool   `hcl:"disable_spiffe_cert_validation" yaml:"disableSpiffeCertValidation"`
 }
 
 type experimentalConfig struct {
-	SyncInterval             string `hcl:"sync_interval"`
-	JWTSVIDCacheHitTimeout   string `hcl:"jwt_svid_cache_hit_timeout"`
-	NamedPipeName            string `hcl:"named_pipe_name"`
-	AdminNamedPipeName       string `hcl:"admin_named_pipe_name"`
-	UseSyncAuthorizedEntries *bool  `hcl:"use_sync_authorized_entries"`
-	RequirePQKEM             bool   `hcl:"require_pq_kem"`
+	SyncInterval             string `hcl:"sync_interval"               yaml:"syncInterval"`
+	JWTSVIDCacheHitTimeout   string `hcl:"jwt_svid_cache_hit_timeout"  yaml:"jwtSvidCacheHitTimeout"`
+	NamedPipeName            string `hcl:"named_pipe_name"             yaml:"namedPipeName"`
+	AdminNamedPipeName       string `hcl:"admin_named_pipe_name"       yaml:"adminNamedPipeName"`
+	UseSyncAuthorizedEntries *bool  `hcl:"use_sync_authorized_entries" yaml:"useSyncAuthorizedEntries"`
+	RequirePQKEM             bool   `hcl:"require_pq_kem"              yaml:"requirePqKem"`
 
-	Flags fflag.RawConfig `hcl:"feature_flags"`
+	Flags fflag.RawConfig `hcl:"feature_flags" yaml:"featureFlags"`
 }
 
 type Command struct {
@@ -298,6 +301,15 @@ func (c *agentConfig) validate() error {
 	return c.validateOS()
 }
 
+func detectFormat(path string) catalog.ConfigFormat {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return catalog.ConfigFormatYAML
+	default:
+		return catalog.ConfigFormatHCL
+	}
+}
+
 func ParseFile(path string, expandEnv bool) (*Config, error) {
 	c := &Config{}
 
@@ -305,17 +317,13 @@ func ParseFile(path string, expandEnv bool) (*Config, error) {
 		path = defaultConfigPath
 	}
 
-	// Return a friendly error if the file is missing
 	byteData, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
-			msg := "could not determine CWD; config file not found at %s: use -config"
-			return nil, fmt.Errorf(msg, path)
+			return nil, fmt.Errorf("could not determine CWD; config file not found at %s: use -config", path)
 		}
-
-		msg := "could not find config file %s: please use the -config flag"
-		return nil, fmt.Errorf(msg, absPath)
+		return nil, fmt.Errorf("could not find config file %s: please use the -config flag", absPath)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to read configuration at %q: %w", path, err)
@@ -327,8 +335,15 @@ func ParseFile(path string, expandEnv bool) (*Config, error) {
 		data = config.ExpandEnv(data)
 	}
 
-	if err := hcl.Decode(&c, data); err != nil {
-		return nil, fmt.Errorf("unable to decode configuration at %q: %w", path, err)
+	switch detectFormat(path) {
+	case catalog.ConfigFormatYAML:
+		if err := yaml.Unmarshal([]byte(data), c); err != nil {
+			return nil, fmt.Errorf("unable to decode YAML configuration at %q: %w", path, err)
+		}
+	default:
+		if err := hcl.Decode(c, data); err != nil {
+			return nil, fmt.Errorf("unable to decode configuration at %q: %w", path, err)
+		}
 	}
 
 	return c, nil
@@ -560,10 +575,17 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 
 	ac.AllowedForeignJWTClaims = c.Agent.AllowedForeignJWTClaims
 
-	ac.PluginConfigs, err = catalog.PluginConfigsFromHCLNode(c.Plugins)
-	if err != nil {
-		return nil, err
+	var pluginConfigs catalog.PluginConfigs
+	if c.PluginsRaw != nil {
+		logger.Warn("YAML configuration support is experimental and may change in future versions")
+		pluginConfigs, err = catalog.PluginConfigsFromYAML(c.PluginsRaw)
+	} else {
+		pluginConfigs, err = catalog.PluginConfigsFromHCLNode(c.Plugins)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("error parsing plugin config: %w", err)
+	}
+	ac.PluginConfigs = pluginConfigs
 
 	ac.Telemetry = c.Telemetry
 	ac.HealthChecks = c.HealthChecks
@@ -613,7 +635,10 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 }
 
 func validateConfig(c *Config) error {
-	if c.Plugins == nil {
+	if c.Plugins != nil && c.PluginsRaw != nil {
+		return errors.New("plugins section must not be configured in both HCL and YAML formats simultaneously")
+	}
+	if c.Plugins == nil && c.PluginsRaw == nil {
 		return errors.New("plugins section must be configured")
 	}
 

--- a/cmd/spire-agent/cli/run/run_posix_test.go
+++ b/cmd/spire-agent/cli/run/run_posix_test.go
@@ -191,7 +191,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_name_agent",
 			Path:       "./pluginAgentCmd",
 			Checksum:   "pluginAgentChecksum",
-			DataSource: catalog.FixedData(data),
+			DataSource: catalog.FixedData{Data: data, Format: catalog.ConfigFormatHCL},
 			Disabled:   false,
 		},
 		{
@@ -199,7 +199,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_disabled",
 			Path:       "./pluginAgentCmd",
 			Checksum:   "pluginAgentChecksum",
-			DataSource: catalog.FixedData(data),
+			DataSource: catalog.FixedData{Data: data, Format: catalog.ConfigFormatHCL},
 			Disabled:   true,
 		},
 		{
@@ -207,7 +207,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_enabled",
 			Path:       "./pluginAgentCmd",
 			Checksum:   "pluginAgentChecksum",
-			DataSource: catalog.FileData("plugin.conf"),
+			DataSource: catalog.FileData{Path: "plugin.conf", Format: catalog.ConfigFormatHCL},
 			Disabled:   false,
 		},
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -38,6 +38,19 @@ type newAgentConfigCase struct {
 	test               func(*testing.T, *agent.Config)
 }
 
+func TestParseFile_YAML(t *testing.T) {
+	path := "../../../../test/fixture/config/agent_good_posix.yaml"
+	c, err := ParseFile(path, false)
+	require.NoError(t, err)
+	require.NotNil(t, c.Agent)
+	require.Equal(t, "127.0.0.1", c.Agent.ServerAddress)
+	require.Equal(t, 8081, c.Agent.ServerPort)
+	require.Equal(t, "example.org", c.Agent.TrustDomain)
+	require.Equal(t, "INFO", c.Agent.LogLevel)
+	require.True(t, c.Agent.AllowUnauthenticatedVerifiers)
+	require.NotNil(t, c.PluginsRaw)
+}
+
 func TestMergeInput(t *testing.T) {
 	cases := []mergeInputCase{
 		{

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -45,6 +46,7 @@ import (
 	"github.com/spiffe/spire/pkg/server/credtemplate"
 	"github.com/spiffe/spire/pkg/server/endpoints/bundle"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -58,148 +60,150 @@ var defaultRateLimit = true
 
 // Config contains all available configurables, arranged by section
 type Config struct {
-	Server             *serverConfig          `hcl:"server"`
-	Plugins            ast.Node               `hcl:"plugins"`
-	Telemetry          telemetry.FileConfig   `hcl:"telemetry"`
-	HealthChecks       health.Config          `hcl:"health_checks"`
+	Server             *serverConfig          `hcl:"server"        yaml:"server"`
+	Plugins            ast.Node               `hcl:"plugins"       yaml:"-"      json:"-"`
+	PluginsRaw         json.RawMessage        `yaml:"plugins"      json:"plugins"`
+	Telemetry          telemetry.FileConfig   `hcl:"telemetry"     yaml:"telemetry"`
+	HealthChecks       health.Config          `hcl:"health_checks" yaml:"healthChecks"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type serverConfig struct {
-	AdminIDs                     []string           `hcl:"admin_ids"`
-	AgentTTL                     string             `hcl:"agent_ttl"`
-	AuditLogEnabled              bool               `hcl:"audit_log_enabled"`
-	BindAddress                  string             `hcl:"bind_address"`
-	BindPort                     int                `hcl:"bind_port"`
-	CAKeyType                    string             `hcl:"ca_key_type"`
-	CASubject                    *caSubjectConfig   `hcl:"ca_subject"`
-	CATTL                        string             `hcl:"ca_ttl"`
-	DataDir                      string             `hcl:"data_dir"`
-	DefaultX509SVIDTTL           string             `hcl:"default_x509_svid_ttl"`
-	DefaultJWTSVIDTTL            string             `hcl:"default_jwt_svid_ttl"`
-	Experimental                 experimentalConfig `hcl:"experimental"`
-	Federation                   *federationConfig  `hcl:"federation"`
-	DisableJWTSVIDs              bool               `hcl:"disable_jwt_svids"`
-	JWTIssuer                    string             `hcl:"jwt_issuer"`
-	JWTKeyType                   string             `hcl:"jwt_key_type"`
-	LogFile                      string             `hcl:"log_file"`
-	LogLevel                     string             `hcl:"log_level"`
-	LogFormat                    string             `hcl:"log_format"`
-	LogSourceLocation            bool               `hcl:"log_source_location"`
-	PruneAttestedNodesExpiredFor string             `hcl:"prune_attested_nodes_expired_for"`
-	PruneNonReattestableNodes    bool               `hcl:"prune_tofu_nodes"`
-	ProxyProtocolTrustedCIDRs    []string           `hcl:"proxy_protocol_trusted_cidrs"`
-	RateLimit                    rateLimitConfig    `hcl:"ratelimit"`
-	SocketPath                   string             `hcl:"socket_path"`
-	TrustDomain                  string             `hcl:"trust_domain"`
-	MaxAttestedNodeInfoStaleness *string            `hcl:"max_attested_node_info_staleness"`
+	AdminIDs                     []string           `hcl:"admin_ids"                          yaml:"adminIds"`
+	AgentTTL                     string             `hcl:"agent_ttl"                          yaml:"agentTtl"`
+	AuditLogEnabled              bool               `hcl:"audit_log_enabled"                  yaml:"auditLogEnabled"`
+	BindAddress                  string             `hcl:"bind_address"                       yaml:"bindAddress"`
+	BindPort                     int                `hcl:"bind_port"                          yaml:"bindPort"`
+	CAKeyType                    string             `hcl:"ca_key_type"                        yaml:"caKeyType"`
+	CASubject                    *caSubjectConfig   `hcl:"ca_subject"                         yaml:"caSubject"`
+	CATTL                        string             `hcl:"ca_ttl"                             yaml:"caTtl"`
+	DataDir                      string             `hcl:"data_dir"                           yaml:"dataDir"`
+	DefaultX509SVIDTTL           string             `hcl:"default_x509_svid_ttl"              yaml:"defaultX509SvidTtl"`
+	DefaultJWTSVIDTTL            string             `hcl:"default_jwt_svid_ttl"               yaml:"defaultJwtSvidTtl"`
+	Experimental                 experimentalConfig `hcl:"experimental"                       yaml:"experimental"`
+	Federation                   *federationConfig  `hcl:"federation"                         yaml:"federation"`
+	DisableJWTSVIDs              bool               `hcl:"disable_jwt_svids"                  yaml:"disableJwtSvids"`
+	JWTIssuer                    string             `hcl:"jwt_issuer"                         yaml:"jwtIssuer"`
+	JWTKeyType                   string             `hcl:"jwt_key_type"                       yaml:"jwtKeyType"`
+	LogFile                      string             `hcl:"log_file"                           yaml:"logFile"`
+	LogLevel                     string             `hcl:"log_level"                          yaml:"logLevel"`
+	LogFormat                    string             `hcl:"log_format"                         yaml:"logFormat"`
+	LogSourceLocation            bool               `hcl:"log_source_location"                yaml:"logSourceLocation"`
+	PruneAttestedNodesExpiredFor string             `hcl:"prune_attested_nodes_expired_for"   yaml:"pruneAttestedNodesExpiredFor"`
+	PruneNonReattestableNodes    bool               `hcl:"prune_tofu_nodes"                   yaml:"pruneTofuNodes"`
+	ProxyProtocolTrustedCIDRs    []string           `hcl:"proxy_protocol_trusted_cidrs"       yaml:"proxyProtocolTrustedCidrs"`
+	RateLimit                    rateLimitConfig    `hcl:"ratelimit"                          yaml:"ratelimit"`
+	SocketPath                   string             `hcl:"socket_path"                        yaml:"socketPath"`
+	TrustDomain                  string             `hcl:"trust_domain"                       yaml:"trustDomain"`
+	MaxAttestedNodeInfoStaleness *string            `hcl:"max_attested_node_info_staleness"   yaml:"maxAttestedNodeInfoStaleness"`
 
 	ConfigPath string
 	ExpandEnv  bool
 
 	// Undocumented configurables
-	ProfilingEnabled bool     `hcl:"profiling_enabled"`
-	ProfilingPort    int      `hcl:"profiling_port"`
-	ProfilingFreq    int      `hcl:"profiling_freq"`
-	ProfilingNames   []string `hcl:"profiling_names"`
+	ProfilingEnabled bool     `hcl:"profiling_enabled" yaml:"profilingEnabled"`
+	ProfilingPort    int      `hcl:"profiling_port"    yaml:"profilingPort"`
+	ProfilingFreq    int      `hcl:"profiling_freq"    yaml:"profilingFreq"`
+	ProfilingNames   []string `hcl:"profiling_names"   yaml:"profilingNames"`
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type experimentalConfig struct {
-	AgentSpiffeIdAsSelector bool                        `hcl:"agent_spiffe_id_as_selector"`
-	AuthOpaPolicyEngine     *authpolicy.OpaEngineConfig `hcl:"auth_opa_policy_engine"`
-	CacheReloadInterval     string                      `hcl:"cache_reload_interval"`
-	FullCacheReloadInterval string                      `hcl:"full_cache_reload_interval"`
-	EventsBasedCache        bool                        `hcl:"events_based_cache"`
-	PruneEventsOlderThan    string                      `hcl:"prune_events_older_than"`
-	EventTimeout            string                      `hcl:"event_timeout"`
-	SQLTransactionTimeout   string                      `hcl:"sql_transaction_timeout"`
-	RequirePQKEM            bool                        `hcl:"require_pq_kem"`
-	WITKeyType              string                      `hcl:"wit_key_type"`
-	WITIssuer               string                      `hcl:"wit_issuer"`
+	AgentSpiffeIdAsSelector bool                        `hcl:"agent_spiffe_id_as_selector" yaml:"agentSpiffeIdAsSelector"`
+	AuthOpaPolicyEngine     *authpolicy.OpaEngineConfig `hcl:"auth_opa_policy_engine"      yaml:"authOpaPolicyEngine"`
+	CacheReloadInterval     string                      `hcl:"cache_reload_interval"       yaml:"cacheReloadInterval"`
+	FullCacheReloadInterval string                      `hcl:"full_cache_reload_interval"  yaml:"fullCacheReloadInterval"`
+	EventsBasedCache        bool                        `hcl:"events_based_cache"          yaml:"eventsBasedCache"`
+	PruneEventsOlderThan    string                      `hcl:"prune_events_older_than"     yaml:"pruneEventsOlderThan"`
+	EventTimeout            string                      `hcl:"event_timeout"               yaml:"eventTimeout"`
+	SQLTransactionTimeout   string                      `hcl:"sql_transaction_timeout"     yaml:"sqlTransactionTimeout"`
+	RequirePQKEM            bool                        `hcl:"require_pq_kem"              yaml:"requirePqKem"`
+	WITKeyType              string                      `hcl:"wit_key_type"                yaml:"witKeyType"`
+	WITIssuer               string                      `hcl:"wit_issuer"                  yaml:"witIssuer"`
 
-	Flags fflag.RawConfig `hcl:"feature_flags"`
+	Flags fflag.RawConfig `hcl:"feature_flags" yaml:"featureFlags"`
 
-	NamedPipeName string `hcl:"named_pipe_name"`
+	NamedPipeName string `hcl:"named_pipe_name" yaml:"namedPipeName"`
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type caSubjectConfig struct {
-	Country            []string               `hcl:"country"`
-	Organization       []string               `hcl:"organization"`
-	CommonName         string                 `hcl:"common_name"`
+	Country            []string               `hcl:"country"       yaml:"country"`
+	Organization       []string               `hcl:"organization"  yaml:"organization"`
+	CommonName         string                 `hcl:"common_name"   yaml:"commonName"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type federationConfig struct {
-	BundleEndpoint     *bundleEndpointConfig          `hcl:"bundle_endpoint"`
-	FederatesWith      map[string]federatesWithConfig `hcl:"federates_with"`
+	BundleEndpoint     *bundleEndpointConfig          `hcl:"bundle_endpoint" yaml:"bundleEndpoint"`
+	FederatesWith      map[string]federatesWithConfig `hcl:"federates_with"  yaml:"federatesWith"`
 	UnusedKeyPositions map[string][]token.Pos         `hcl:",unusedKeyPositions"`
 }
 
 type bundleEndpointConfig struct {
-	Address     string `hcl:"address"`
-	Port        int    `hcl:"port"`
-	RefreshHint string `hcl:"refresh_hint"`
+	Address     string `hcl:"address"      yaml:"address"`
+	Port        int    `hcl:"port"         yaml:"port"`
+	RefreshHint string `hcl:"refresh_hint" yaml:"refreshHint"`
 
-	ACME    *bundleEndpointACMEConfig `hcl:"acme"`
-	Profile ast.Node                  `hcl:"profile"`
+	ACME    *bundleEndpointACMEConfig `hcl:"acme"    yaml:"acme"`
+	Profile ast.Node                  `hcl:"profile" yaml:"-" json:"-"`
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type bundleEndpointConfigProfile struct {
-	HTTPSSPIFFE        *bundleEndpointProfileHTTPSSPIFFEConfig `hcl:"https_spiffe"`
-	HTTPSWeb           *bundleEndpointProfileHTTPSWebConfig    `hcl:"https_web"`
+	HTTPSSPIFFE        *bundleEndpointProfileHTTPSSPIFFEConfig `hcl:"https_spiffe" yaml:"httpsSpiffe"`
+	HTTPSWeb           *bundleEndpointProfileHTTPSWebConfig    `hcl:"https_web"    yaml:"httpsWeb"`
 	UnusedKeyPositions map[string][]token.Pos                  `hcl:",unusedKeyPositions"`
 }
 
 type bundleEndpointProfileHTTPSWebConfig struct {
-	ACME            *bundleEndpointACMEConfig      `hcl:"acme"`
-	ServingCertFile *bundleEndpointServingCertFile `hcl:"serving_cert_file"`
+	ACME            *bundleEndpointACMEConfig      `hcl:"acme"              yaml:"acme"`
+	ServingCertFile *bundleEndpointServingCertFile `hcl:"serving_cert_file" yaml:"servingCertFile"`
 }
 
 type bundleEndpointProfileHTTPSSPIFFEConfig struct{}
 
 type bundleEndpointServingCertFile struct {
-	CertFilePath        string        `hcl:"cert_file_path"`
-	KeyFilePath         string        `hcl:"key_file_path"`
-	FileSyncInterval    time.Duration `hcl:"-"`
-	RawFileSyncInterval string        `hcl:"file_sync_interval"`
+	CertFilePath        string        `hcl:"cert_file_path"     yaml:"certFilePath"`
+	KeyFilePath         string        `hcl:"key_file_path"      yaml:"keyFilePath"`
+	FileSyncInterval    time.Duration `hcl:"-"                  yaml:"-"`
+	RawFileSyncInterval string        `hcl:"file_sync_interval" yaml:"fileSyncInterval"`
 }
 
 type bundleEndpointACMEConfig struct {
-	DirectoryURL       string                 `hcl:"directory_url"`
-	DomainName         string                 `hcl:"domain_name"`
-	Email              string                 `hcl:"email"`
-	ToSAccepted        bool                   `hcl:"tos_accepted"`
+	DirectoryURL       string                 `hcl:"directory_url" yaml:"directoryUrl"`
+	DomainName         string                 `hcl:"domain_name"   yaml:"domainName"`
+	Email              string                 `hcl:"email"         yaml:"email"`
+	ToSAccepted        bool                   `hcl:"tos_accepted"  yaml:"tosAccepted"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type federatesWithConfig struct {
-	BundleEndpointURL     string                 `hcl:"bundle_endpoint_url"`
-	BundleEndpointProfile ast.Node               `hcl:"bundle_endpoint_profile"`
+	BundleEndpointURL            string                        `hcl:"bundle_endpoint_url"      yaml:"bundleEndpointUrl"`
+	BundleEndpointProfile        ast.Node                      `hcl:"bundle_endpoint_profile"  yaml:"-"    json:"-"`
+	BundleEndpointProfileConfig  *bundleEndpointProfileConfig  `yaml:"bundleEndpointProfile"`
 	UnusedKeyPositions    map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type bundleEndpointProfileConfig struct {
-	HTTPSSPIFFE        *httpsSPIFFEProfileConfig `hcl:"https_spiffe"`
-	HTTPSWeb           *httpsWebProfileConfig    `hcl:"https_web"`
+	HTTPSSPIFFE        *httpsSPIFFEProfileConfig `hcl:"https_spiffe" yaml:"httpsSpiffe"`
+	HTTPSWeb           *httpsWebProfileConfig    `hcl:"https_web"    yaml:"httpsWeb"`
 	UnusedKeyPositions map[string][]token.Pos    `hcl:",unusedKeyPositions"`
 }
 
 type httpsSPIFFEProfileConfig struct {
-	EndpointSPIFFEID   string                 `hcl:"endpoint_spiffe_id"`
+	EndpointSPIFFEID   string                 `hcl:"endpoint_spiffe_id" yaml:"endpointSpiffeId"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
 type httpsWebProfileConfig struct{}
 
 type rateLimitConfig struct {
-	Attestation        *bool                  `hcl:"attestation"`
-	Signing            *bool                  `hcl:"signing"`
+	Attestation        *bool                  `hcl:"attestation" yaml:"attestation"`
+	Signing            *bool                  `hcl:"signing"     yaml:"signing"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
@@ -300,6 +304,15 @@ func (*Command) Synopsis() string {
 	return "Runs the server"
 }
 
+func detectFormat(path string) catalog.ConfigFormat {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return catalog.ConfigFormatYAML
+	default:
+		return catalog.ConfigFormatHCL
+	}
+}
+
 func ParseFile(path string, expandEnv bool) (*Config, error) {
 	c := &Config{}
 
@@ -307,17 +320,13 @@ func ParseFile(path string, expandEnv bool) (*Config, error) {
 		path = defaultConfigPath
 	}
 
-	// Return a friendly error if the file is missing
 	byteData, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		absPath, err := filepath.Abs(path)
 		if err != nil {
-			msg := "could not determine CWD; config file not found at %s: use -config"
-			return nil, fmt.Errorf(msg, path)
+			return nil, fmt.Errorf("could not determine CWD; config file not found at %s: use -config", path)
 		}
-
-		msg := "could not find config file %s: please use the -config flag"
-		return nil, fmt.Errorf(msg, absPath)
+		return nil, fmt.Errorf("could not find config file %s: please use the -config flag", absPath)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to read configuration at %q: %w", path, err)
@@ -329,8 +338,15 @@ func ParseFile(path string, expandEnv bool) (*Config, error) {
 		data = config.ExpandEnv(data)
 	}
 
-	if err := hcl.Decode(&c, data); err != nil {
-		return nil, fmt.Errorf("unable to decode configuration at %q: %w", path, err)
+	switch detectFormat(path) {
+	case catalog.ConfigFormatYAML:
+		if err := yaml.Unmarshal([]byte(data), c); err != nil {
+			return nil, fmt.Errorf("unable to decode YAML configuration at %q: %w", path, err)
+		}
+	default:
+		if err := hcl.Decode(c, data); err != nil {
+			return nil, fmt.Errorf("unable to decode configuration at %q: %w", path, err)
+		}
 	}
 
 	return c, nil
@@ -503,6 +519,11 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 			switch {
 			case config.BundleEndpointProfile != nil:
 				trustDomainConfig, err = parseBundleEndpointProfile(config)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing federation relationship for trust domain %q: %w", trustDomain, err)
+				}
+			case config.BundleEndpointProfileConfig != nil:
+				trustDomainConfig, err = parseBundleEndpointProfileFromConfig(config)
 				if err != nil {
 					return nil, fmt.Errorf("error parsing federation relationship for trust domain %q: %w", trustDomain, err)
 				}
@@ -694,10 +715,17 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		sc.CASubject = credtemplate.DefaultX509CASubject()
 	}
 
-	sc.PluginConfigs, err = catalog.PluginConfigsFromHCLNode(c.Plugins)
-	if err != nil {
-		return nil, err
+	var pluginConfigs catalog.PluginConfigs
+	if c.PluginsRaw != nil {
+		sc.Log.Warn("YAML configuration support is experimental and may change in future versions")
+		pluginConfigs, err = catalog.PluginConfigsFromYAML(c.PluginsRaw)
+	} else {
+		pluginConfigs, err = catalog.PluginConfigsFromHCLNode(c.Plugins)
 	}
+	if err != nil {
+		return nil, fmt.Errorf("error parsing plugin config: %w", err)
+	}
+	sc.PluginConfigs = pluginConfigs
 	sc.Telemetry = c.Telemetry
 	sc.HealthChecks = c.HealthChecks
 
@@ -867,6 +895,29 @@ func configToDiskCertManager(serviceCertFile *bundleEndpointServingCertFile, log
 	)
 }
 
+func parseBundleEndpointProfileFromConfig(config federatesWithConfig) (*bundleClient.TrustDomainConfig, error) {
+	profileConfig := config.BundleEndpointProfileConfig
+
+	var endpointProfile bundleClient.EndpointProfileInfo
+	switch {
+	case profileConfig.HTTPSWeb != nil:
+		endpointProfile = bundleClient.HTTPSWebProfile{}
+	case profileConfig.HTTPSSPIFFE != nil:
+		spiffeID, err := spiffeid.FromString(profileConfig.HTTPSSPIFFE.EndpointSPIFFEID)
+		if err != nil {
+			return nil, fmt.Errorf("could not get endpoint SPIFFE ID: %w", err)
+		}
+		endpointProfile = bundleClient.HTTPSSPIFFEProfile{EndpointSPIFFEID: spiffeID}
+	default:
+		return nil, errors.New(`no bundle endpoint profile defined; current supported profiles are "https_spiffe" and "https_web"`)
+	}
+
+	return &bundleClient.TrustDomainConfig{
+		EndpointURL:     config.BundleEndpointURL,
+		EndpointProfile: endpointProfile,
+	}, nil
+}
+
 func parseBundleEndpointProfile(config federatesWithConfig) (trustDomainConfig *bundleClient.TrustDomainConfig, err error) {
 	configString, err := parseBundleEndpointProfileASTNode(config.BundleEndpointProfile)
 	if err != nil {
@@ -932,7 +983,10 @@ func validateConfig(c *Config) error {
 		return errors.New("data_dir must be configured")
 	}
 
-	if c.Plugins == nil {
+	if c.Plugins != nil && c.PluginsRaw != nil {
+		return errors.New("plugins section must not be configured in both HCL and YAML formats simultaneously")
+	}
+	if c.Plugins == nil && c.PluginsRaw == nil {
 		return errors.New("plugins section must be configured")
 	}
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -78,7 +78,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_name_server",
 			Path:       "./pluginServerCmd",
 			Checksum:   "pluginServerChecksum",
-			DataSource: catalog.FixedData(data),
+			DataSource: catalog.FixedData{Data: data, Format: catalog.ConfigFormatHCL},
 			Disabled:   false,
 		},
 		{
@@ -86,7 +86,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_disabled",
 			Path:       "./pluginServerCmd",
 			Checksum:   "pluginServerChecksum",
-			DataSource: catalog.FixedData(data),
+			DataSource: catalog.FixedData{Data: data, Format: catalog.ConfigFormatHCL},
 			Disabled:   true,
 		},
 		{
@@ -94,7 +94,7 @@ func TestParseConfigGood(t *testing.T) {
 			Name:       "plugin_enabled",
 			Path:       "./pluginServerCmd",
 			Checksum:   "pluginServerChecksum",
-			DataSource: catalog.FileData("plugin.conf"),
+			DataSource: catalog.FileData{Path: "plugin.conf", Format: catalog.ConfigFormatHCL},
 			Disabled:   false,
 		},
 	}
@@ -102,6 +102,20 @@ func TestParseConfigGood(t *testing.T) {
 	pluginConfigs, err := catalog.PluginConfigsFromHCLNode(c.Plugins)
 	require.NoError(t, err)
 	require.Equal(t, expectedPluginConfigs, pluginConfigs)
+}
+
+func TestParseFile_YAML(t *testing.T) {
+	path := "../../../../test/fixture/config/server_good_posix.yaml"
+	c, err := ParseFile(path, false)
+	require.NoError(t, err)
+	require.NotNil(t, c.Server)
+	require.Equal(t, "127.0.0.1", c.Server.BindAddress)
+	require.Equal(t, 8081, c.Server.BindPort)
+	require.Equal(t, "example.org", c.Server.TrustDomain)
+	require.Equal(t, "INFO", c.Server.LogLevel)
+	require.True(t, c.Server.AuditLogEnabled)
+	require.NotNil(t, c.Server.Federation)
+	require.NotNil(t, c.PluginsRaw)
 }
 
 func TestMergeInput(t *testing.T) {
@@ -2000,6 +2014,28 @@ func TestMinCATTL(t *testing.T) {
 		} else {
 			assert.Equal(t, v.expect, printMinCATTL(v.jwtSVIDTTL))
 		}
+	}
+}
+
+func TestDetectFormat(t *testing.T) {
+	tests := []struct {
+		path   string
+		expect catalog.ConfigFormat
+	}{
+		{"spire.yaml", catalog.ConfigFormatYAML},
+		{"spire.yml", catalog.ConfigFormatYAML},
+		{"SPIRE.YAML", catalog.ConfigFormatYAML},
+		{"SPIRE.YML", catalog.ConfigFormatYAML},
+		{"spire.conf", catalog.ConfigFormatHCL},
+		{"spire.hcl", catalog.ConfigFormatHCL},
+		{"spire", catalog.ConfigFormatHCL},
+		{"/etc/spire/server.yaml", catalog.ConfigFormatYAML},
+		{"/etc/spire/server.conf", catalog.ConfigFormatHCL},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			require.Equal(t, tt.expect, detectFormat(tt.path))
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -334,4 +334,4 @@ require (
 )
 
 // TODO: remove replace once spire-plugin-sdk PR is merged and published
-replace github.com/spiffe/spire-plugin-sdk => /Users/marcosyacob/opensource/spire-plugin-sdk
+replace github.com/spiffe/spire-plugin-sdk => github.com/MarcosDY/spire-plugin-sdk v0.0.0-20260509215151-58a62ba3a649

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	k8s.io/kube-aggregator v0.36.0
 	k8s.io/mount-utils v0.36.0
 	sigs.k8s.io/controller-runtime v0.24.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -330,5 +331,7 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// TODO: remove replace once spire-plugin-sdk PR is merged and published
+replace github.com/spiffe/spire-plugin-sdk => /Users/marcosyacob/opensource/spire-plugin-sdk

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/Keyfactor/ejbca-go-client-sdk v1.1.0 h1:d84RX+9QRO+b9nV/1jNo3t0/Xg92A4gXG+7fsG/WDgI=
 github.com/Keyfactor/ejbca-go-client-sdk v1.1.0/go.mod h1:WtJ+IY1LjAuJjvwDy+oQ/UJ+bktHen1igaaSqOdIcQE=
+github.com/MarcosDY/spire-plugin-sdk v0.0.0-20260509215151-58a62ba3a649 h1:CU7tiuTDgrjq1xzb9wjfKZbe6z7wKjSvy4kSeVHafag=
+github.com/MarcosDY/spire-plugin-sdk v0.0.0-20260509215151-58a62ba3a649/go.mod h1:QvrRDiBlXiJ7kNd176ZHsF5eklxxeTRgJSu2CXe0MKw=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/go.sum
+++ b/go.sum
@@ -811,8 +811,6 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20260320104153-99d433165a01 h1:FA0UhZ5fOca/d/ogmVHif1eDARpMo4FLWUnav8JzEts=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20260320104153-99d433165a01/go.mod h1:9hXJcMzatM1KwAtBDO3s6HccDCic++/5c2yOc5Iln8Y=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20251120194148-791bbd274dc7 h1:OAvr7TNirmBpXnAp82cTosuB+JAus5cyFCRqXHE0WHs=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20251120194148-791bbd274dc7/go.mod h1:QvrRDiBlXiJ7kNd176ZHsF5eklxxeTRgJSu2CXe0MKw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"cmp"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -9,12 +10,12 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	keymanagerbase "github.com/spiffe/spire/pkg/agent/plugin/keymanager/base"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -36,7 +37,7 @@ func asBuiltIn(p *KeyManager) catalog.BuiltIn {
 }
 
 type configuration struct {
-	Directory string `hcl:"directory"`
+	Directory string `hcl:"directory" yaml:"directory"`
 }
 
 type KeyManager struct {
@@ -64,7 +65,12 @@ func (m *KeyManager) SetLogger(log hclog.Logger) {
 
 func (m *KeyManager) Configure(_ context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
 	config := new(configuration)
-	if err := hcl.Decode(config, req.HclConfiguration); err != nil {
+	format := catalog.ConfigFormatHCL
+	if req.GetConfigFormat() == configv1.ConfigFormat_CONFIG_FORMAT_YAML {
+		format = catalog.ConfigFormatYAML
+	}
+	configText := cmp.Or(req.GetConfiguration(), req.GetHclConfiguration())
+	if err := plugindecode.DecodeConfig(configText, format, config); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)
 	}
 

--- a/pkg/agent/plugin/nodeattestor/awsiid/iid.go
+++ b/pkg/agent/plugin/nodeattestor/awsiid/iid.go
@@ -10,12 +10,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -38,12 +38,12 @@ func builtin(p *IIDAttestorPlugin) catalog.BuiltIn {
 
 // IIDAttestorConfig configures a IIDAttestorPlugin.
 type IIDAttestorConfig struct {
-	EC2MetadataEndpoint string `hcl:"ec2_metadata_endpoint"`
+	EC2MetadataEndpoint string `hcl:"ec2_metadata_endpoint" yaml:"ec2MetadataEndpoint"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IIDAttestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *IIDAttestorConfig {
 	newConfig := &IIDAttestorConfig{}
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/azureimds/imds.go
+++ b/pkg/agent/plugin/nodeattestor/azureimds/imds.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -33,12 +33,12 @@ func builtin(p *IMDSAttestorPlugin) catalog.BuiltIn {
 
 type IMDSAttestorConfig struct {
 	// TenantDomain is the domain of the tenant in which the VM is running.
-	TenantDomain string `hcl:"tenant_domain"`
+	TenantDomain string `hcl:"tenant_domain" yaml:"tenantDomain"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IMDSAttestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *IMDSAttestorConfig {
 	newConfig := new(IMDSAttestorConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/azuremsi/msi.go
+++ b/pkg/agent/plugin/nodeattestor/azuremsi/msi.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -38,12 +38,12 @@ type MSIAttestorConfig struct {
 	// application they registered with the active directory to limit the scope
 	// of use of the token. A bogus value cannot be used; Azure makes sure the
 	// resource ID is either an azure service ID or a registered app ID.
-	ResourceID string `hcl:"resource_id"`
+	ResourceID string `hcl:"resource_id" yaml:"resourceID"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *MSIAttestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *MSIAttestorConfig {
 	newConfig := new(MSIAttestorConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/gcpiit/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcpiit/iit.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 )
 
 const (
@@ -47,13 +47,13 @@ type IITAttestorPlugin struct {
 
 // IITAttestorConfig configures a IITAttestorPlugin.
 type IITAttestorConfig struct {
-	IdentityTokenHost string `hcl:"identity_token_host"`
-	ServiceAccount    string `hcl:"service_account"`
+	IdentityTokenHost string `hcl:"identity_token_host" yaml:"identityTokenHost"`
+	ServiceAccount    string `hcl:"service_account" yaml:"serviceAccount"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IITAttestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *IITAttestorConfig {
 	newConfig := &IITAttestorConfig{}
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/httpchallenge"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -43,15 +43,15 @@ type configData struct {
 }
 
 type Config struct {
-	HostName       string `hcl:"hostname"`
-	AgentName      string `hcl:"agentname"`
-	Port           int    `hcl:"port"`
-	AdvertisedPort int    `hcl:"advertised_port"`
+	HostName       string `hcl:"hostname" yaml:"hostname"`
+	AgentName      string `hcl:"agentname" yaml:"agentname"`
+	Port           int    `hcl:"port" yaml:"port"`
+	AdvertisedPort int    `hcl:"advertised_port" yaml:"advertisedPort"`
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configData {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *configData {
 	hclConfig := new(Config)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 	}
 

--- a/pkg/agent/plugin/nodeattestor/k8spsat/psat.go
+++ b/pkg/agent/plugin/nodeattestor/k8spsat/psat.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -50,14 +50,14 @@ type AttestorPlugin struct {
 // AttestorConfig holds configuration for AttestorPlugin
 type AttestorConfig struct {
 	// Cluster name where the agent lives
-	Cluster string `hcl:"cluster"`
+	Cluster string `hcl:"cluster" yaml:"cluster"`
 	// File path of PSAT
-	TokenPath string `hcl:"token_path"`
+	TokenPath string `hcl:"token_path" yaml:"tokenPath"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *attestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *attestorConfig {
 	hclConfig := new(AttestorConfig)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid.go
@@ -9,13 +9,13 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	common_devid "github.com/spiffe/spire/pkg/common/plugin/tpmdevid"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,21 +40,21 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Config struct {
-	DevIDPrivPath string `hcl:"devid_priv_path"`
-	DevIDPubPath  string `hcl:"devid_pub_path"`
-	DevIDCertPath string `hcl:"devid_cert_path"`
+	DevIDPrivPath string `hcl:"devid_priv_path" yaml:"devIDPrivPath"`
+	DevIDPubPath  string `hcl:"devid_pub_path" yaml:"devIDPubPath"`
+	DevIDCertPath string `hcl:"devid_cert_path" yaml:"devIDCertPath"`
 
-	DevIDKeyPassword             string `hcl:"devid_password"`
-	OwnerHierarchyPassword       string `hcl:"owner_hierarchy_password"`
-	EndorsementHierarchyPassword string `hcl:"endorsement_hierarchy_password"`
+	DevIDKeyPassword             string `hcl:"devid_password" yaml:"devIDKeyPassword"`
+	OwnerHierarchyPassword       string `hcl:"owner_hierarchy_password" yaml:"ownerHierarchyPassword"`
+	EndorsementHierarchyPassword string `hcl:"endorsement_hierarchy_password" yaml:"endorsementHierarchyPassword"`
 
-	DevicePath string `hcl:"tpm_device_path"`
+	DevicePath string `hcl:"tpm_device_path" yaml:"devicePath"`
 	Autodetect bool
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,15 +40,15 @@ type configData struct {
 }
 
 type Config struct {
-	PrivateKeyPath       string `hcl:"private_key_path"`
-	CertificatePath      string `hcl:"certificate_path"`
-	IntermediatesPath    string `hcl:"intermediates_path"`
-	SpiffeEndpointSocket string `hcl:"spiffe_endpoint_socket"`
+	PrivateKeyPath       string `hcl:"private_key_path" yaml:"privateKeyPath"`
+	CertificatePath      string `hcl:"certificate_path" yaml:"certificatePath"`
+	IntermediatesPath    string `hcl:"intermediates_path" yaml:"intermediatesPath"`
+	SpiffeEndpointSocket string `hcl:"spiffe_endpoint_socket" yaml:"spiffeEndpointSocket"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/svidstore/awssecretsmanager/aws.go
+++ b/pkg/agent/plugin/svidstore/awssecretsmanager/aws.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	svidstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/svidstore/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/plugin/svidstore"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -49,14 +49,14 @@ func newPlugin(newClient func(ctx context.Context, secretAccessKey, accessKeyID,
 }
 
 type Configuration struct {
-	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id"`
-	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key"`
-	Region          string `hcl:"region" json:"region"`
+	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key" yaml:"secretAccessKey"`
+	Region          string `hcl:"region" json:"region" yaml:"region"`
 }
 
-func (p *SecretsManagerPlugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func (p *SecretsManagerPlugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := &Configuration{}
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud.go
+++ b/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud.go
@@ -12,13 +12,13 @@ import (
 	"cloud.google.com/go/iam/apiv1/iampb"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/token"
 	svidstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/svidstore/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/plugin/svidstore"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -50,13 +50,13 @@ func newPlugin(newSecretManagerClient func(context.Context, string) (secretManag
 }
 
 type Configuration struct {
-	ServiceAccountFile string                 `hcl:"service_account_file" json:"service_account_file"`
-	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions" json:",omitempty"`
+	ServiceAccountFile string                 `hcl:"service_account_file" json:"service_account_file" yaml:"serviceAccountFile"`
+	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions" json:",omitempty" yaml:"-"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := &Configuration{}
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -10,13 +10,13 @@ import (
 	"github.com/docker/docker/api/types/image"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/token"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/common/sigstore"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -84,22 +84,22 @@ type dockerPluginConfig struct {
 	OSConfig `hcl:",squash"`
 
 	// DockerVersion is the API version of the docker daemon. If not specified, the version is negotiated by the client.
-	DockerVersion string `hcl:"docker_version" json:"docker_version"`
+	DockerVersion string `hcl:"docker_version" json:"docker_version" yaml:"dockerVersion"`
 
-	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
+	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions" yaml:"-"`
 
 	// Sigstore contains sigstore specific configs.
-	Sigstore *sigstore.HCLConfig `hcl:"sigstore,omitempty" json:"sigstore"`
+	Sigstore *sigstore.HCLConfig `hcl:"sigstore,omitempty" json:"sigstore" yaml:"sigstore,omitempty"`
 
 	containerHelper *containerHelper
 	dockerOpts      []dockerclient.Opt
 	sigstoreConfig  *sigstore.Config
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *dockerPluginConfig {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *dockerPluginConfig {
 	var err error
 	newConfig := &dockerPluginConfig{}
-	if err = hcl.Decode(newConfig, hclText); err != nil {
+	if err = plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/workloadattestor/docker/docker_posix.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_posix.go
@@ -30,29 +30,29 @@ var (
 
 type OSConfig struct {
 	// DockerSocketPath is the location of the docker daemon socket, this config can be used only on unix environments (default: "unix:///var/run/docker.sock").
-	DockerSocketPath string `hcl:"docker_socket_path" json:"docker_socket_path"`
+	DockerSocketPath string `hcl:"docker_socket_path" json:"docker_socket_path" yaml:"dockerSocketPath"`
 
 	// ContainerIDCGroupMatchers is a list of patterns used to discover container IDs from cgroup entries.
 	// See the documentation for cgroup.NewContainerIDFinder in the cgroup subpackage for more information. (Unix)
-	ContainerIDCGroupMatchers []string `hcl:"container_id_cgroup_matchers" json:"container_id_cgroup_matchers"`
+	ContainerIDCGroupMatchers []string `hcl:"container_id_cgroup_matchers" json:"container_id_cgroup_matchers" yaml:"containerIDCGroupMatchers"`
 
 	// UseNewContainerLocator, if true, uses the new container locator
 	// mechanism instead of cgroup matchers. Currently defaults to false if
 	// unset. This will default to true in a future release. (Unix)
-	UseNewContainerLocator *bool `hcl:"use_new_container_locator"`
+	UseNewContainerLocator *bool `hcl:"use_new_container_locator" yaml:"useNewContainerLocator,omitempty"`
 
 	// VerboseContainerLocatorLogs, if true, dumps extra information to the log
 	// about mountinfo and cgroup information used to locate the container.
-	VerboseContainerLocatorLogs bool `hcl:"verbose_container_locator_logs"`
+	VerboseContainerLocatorLogs bool `hcl:"verbose_container_locator_logs" yaml:"verboseContainerLocatorLogs"`
 
 	// PodmanSocketPath is the socket path for rootful Podman (no user namespace).
 	// Defaults to "unix:///run/podman/podman.sock".
-	PodmanSocketPath string `hcl:"podman_socket_path" json:"podman_socket_path"`
+	PodmanSocketPath string `hcl:"podman_socket_path" json:"podman_socket_path" yaml:"podmanSocketPath"`
 
 	// PodmanSocketPathTemplate is the socket path template for rootless Podman.
 	// The placeholder %d is replaced with the container owner's host UID extracted
 	// from the cgroup path. Defaults to "unix:///run/user/%d/podman/podman.sock".
-	PodmanSocketPathTemplate string `hcl:"podman_socket_path_template" json:"podman_socket_path_template"`
+	PodmanSocketPathTemplate string `hcl:"podman_socket_path_template" json:"podman_socket_path_template" yaml:"podmanSocketPathTemplate"`
 
 	// Used by tests to use a fake /proc directory instead of the real one
 	rootDir string

--- a/pkg/agent/plugin/workloadattestor/docker/docker_windows.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_windows.go
@@ -12,7 +12,7 @@ import (
 
 type OSConfig struct {
 	// DockerHost is the location of the Docker Engine API endpoint on Windows (default: "npipe:////./pipe/docker_engine").
-	DockerHost string `hcl:"docker_host" json:"docker_host"`
+	DockerHost string `hcl:"docker_host" json:"docker_host" yaml:"dockerHost"`
 }
 
 func (p *Plugin) createHelper(*dockerPluginConfig, *pluginconf.Status) *containerHelper {

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	hcltoken "github.com/hashicorp/hcl/hcl/token"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -27,6 +26,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/valyala/fastjson"
 	"golang.org/x/sync/singleflight"
@@ -63,81 +63,81 @@ type HCLConfig struct {
 	// KubeletReadOnlyPort defines the read only port for the kubelet
 	// (typically 10255). This option is mutually exclusive with
 	// KubeletSecurePort.
-	KubeletReadOnlyPort int `hcl:"kubelet_read_only_port"`
+	KubeletReadOnlyPort int `hcl:"kubelet_read_only_port" yaml:"kubeletReadOnlyPort"`
 
 	// KubeletSecurePort defines the secure port for the kubelet (typically
 	// 10250). This option is mutually exclusive with KubeletReadOnlyPort.
-	KubeletSecurePort int `hcl:"kubelet_secure_port"`
+	KubeletSecurePort int `hcl:"kubelet_secure_port" yaml:"kubeletSecurePort"`
 
 	// MaxPollAttempts is the maximum number of polling attempts for the
 	// container hosting the workload process.
-	MaxPollAttempts int `hcl:"max_poll_attempts"`
+	MaxPollAttempts int `hcl:"max_poll_attempts" yaml:"maxPollAttempts"`
 
 	// PollRetryInterval is the time in between polling attempts.
-	PollRetryInterval string `hcl:"poll_retry_interval"`
+	PollRetryInterval string `hcl:"poll_retry_interval" yaml:"pollRetryInterval"`
 
 	// KubeletCAPath is the path to the CA certificate for authenticating the
 	// kubelet over the secure port. Required when using the secure port unless
 	// SkipKubeletVerification is set. Defaults to the cluster trust bundle.
-	KubeletCAPath string `hcl:"kubelet_ca_path"`
+	KubeletCAPath string `hcl:"kubelet_ca_path" yaml:"kubeletCAPath"`
 
 	// SkipKubeletVerification controls whether the plugin will
 	// verify the certificate presented by the kubelet.
-	SkipKubeletVerification bool `hcl:"skip_kubelet_verification"`
+	SkipKubeletVerification bool `hcl:"skip_kubelet_verification" yaml:"skipKubeletVerification"`
 
 	// TokenPath is the path to the bearer token used to authenticate to the
 	// secure port. Defaults to the default service account token path unless
 	// PrivateKeyPath and CertificatePath are specified.
-	TokenPath string `hcl:"token_path"`
+	TokenPath string `hcl:"token_path" yaml:"tokenPath"`
 
 	// CertificatePath is the path to a certificate key used for client
 	// authentication with the kubelet. Must be used with PrivateKeyPath.
-	CertificatePath string `hcl:"certificate_path"`
+	CertificatePath string `hcl:"certificate_path" yaml:"certificatePath"`
 
 	// PrivateKeyPath is the path to a private key used for client
 	// authentication with the kubelet. Must be used with CertificatePath.
-	PrivateKeyPath string `hcl:"private_key_path"`
+	PrivateKeyPath string `hcl:"private_key_path" yaml:"privateKeyPath"`
 
 	// UseAnonymousAuthentication controls whether communication to the
 	// kubelet over the secure port is unauthenticated. This option is mutually
 	// exclusive with other authentication configuration fields TokenPath,
 	// CertificatePath, and PrivateKeyPath.
-	UseAnonymousAuthentication bool `hcl:"use_anonymous_authentication"`
+	UseAnonymousAuthentication bool `hcl:"use_anonymous_authentication" yaml:"useAnonymousAuthentication"`
 
 	// NodeNameEnv is the environment variable used to determine the node name
 	// for contacting the kubelet. It defaults to "MY_NODE_NAME". If the
 	// environment variable is not set, and NodeName is not specified, the
 	// plugin will default to localhost (which requires host networking).
-	NodeNameEnv string `hcl:"node_name_env"`
+	NodeNameEnv string `hcl:"node_name_env" yaml:"nodeNameEnv"`
 
 	// NodeName is the node name used when contacting the kubelet. If set, it
 	// takes precedence over NodeNameEnv.
-	NodeName string `hcl:"node_name"`
+	NodeName string `hcl:"node_name" yaml:"nodeName"`
 
 	// ReloadInterval controls how often TLS and token configuration is loaded
 	// from the disk.
-	ReloadInterval string `hcl:"reload_interval"`
+	ReloadInterval string `hcl:"reload_interval" yaml:"reloadInterval"`
 
 	// DisableContainerSelectors disables the gathering of selectors for the
 	// specific container running the workload. This allows attestation to
 	// succeed with just pod related selectors when the workload pod is known
 	// but the container may not be in a ready state at the time of attestation
 	// (e.g. when a postStart hook has yet to complete).
-	DisableContainerSelectors bool `hcl:"disable_container_selectors"`
+	DisableContainerSelectors bool `hcl:"disable_container_selectors" yaml:"disableContainerSelectors"`
 
 	// UseNewContainerLocator, if true, uses the new container locator
 	// mechanism instead of the legacy cgroup matchers. Defaults to true if
 	// unset. This configurable will be removed in a future release.
-	UseNewContainerLocator *bool `hcl:"use_new_container_locator"`
+	UseNewContainerLocator *bool `hcl:"use_new_container_locator" yaml:"useNewContainerLocator,omitempty"`
 
 	// VerboseContainerLocatorLogs, if true, dumps extra information to the log
 	// about mountinfo and cgroup information used to locate the container.
-	VerboseContainerLocatorLogs bool `hcl:"verbose_container_locator_logs"`
+	VerboseContainerLocatorLogs bool `hcl:"verbose_container_locator_logs" yaml:"verboseContainerLocatorLogs"`
 
 	// Sigstore contains sigstore specific configs.
-	Sigstore *sigstore.HCLConfig `hcl:"sigstore,omitempty"`
+	Sigstore *sigstore.HCLConfig `hcl:"sigstore,omitempty" yaml:"sigstore,omitempty"`
 
-	UnusedKeyPositions map[string][]hcltoken.Pos `hcl:",unusedKeyPositions"`
+	UnusedKeyPositions map[string][]hcltoken.Pos `hcl:",unusedKeyPositions" yaml:"-"`
 }
 
 // k8sConfig holds the configuration distilled from HCL
@@ -162,10 +162,10 @@ type k8sConfig struct {
 	LastReload time.Time
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *k8sConfig {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *k8sConfig {
 	// Parse HCL config payload into config struct
 	newConfig := new(HCLConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/shirou/gopsutil/v4/process"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -88,13 +88,13 @@ func (ps PSProcessInfo) Groups() ([]string, error) {
 }
 
 type Configuration struct {
-	DiscoverWorkloadPath bool  `hcl:"discover_workload_path"`
-	WorkloadSizeLimit    int64 `hcl:"workload_size_limit"`
+	DiscoverWorkloadPath bool  `hcl:"discover_workload_path" yaml:"discoverWorkloadPath"`
+	WorkloadSizeLimit    int64 `hcl:"workload_size_limit" yaml:"workloadSizeLimit"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("failed to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/util"
@@ -33,13 +33,13 @@ func New() *Plugin {
 }
 
 type Configuration struct {
-	DiscoverWorkloadPath bool  `hcl:"discover_workload_path"`
-	WorkloadSizeLimit    int64 `hcl:"workload_size_limit"`
+	DiscoverWorkloadPath bool  `hcl:"discover_workload_path" yaml:"discoverWorkloadPath"`
+	WorkloadSizeLimit    int64 `hcl:"workload_size_limit" yaml:"workloadSizeLimit"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("failed to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -302,10 +302,12 @@ func ValidatePluginConfigs(ctx context.Context, config Config, repo Repository) 
 
 func GetPluginConfigString(c PluginConfig) (string, error) {
 	if c.DataSource == nil {
-		return FixedData("").Load()
+		data, _, err := FixedData{}.Load()
+		return data, err
 	}
 
-	return c.DataSource.Load()
+	data, _, err := c.DataSource.Load()
+	return data, err
 }
 
 func makePluginLog(log logrus.FieldLogger, pluginConfig PluginConfig) logrus.FieldLogger {

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -220,7 +220,7 @@ func testPlugin(t *testing.T, pluginPath string) {
 		testLoad(t, pluginPath, loadTest{
 			registerConfigService: true,
 			mutateConfig: func(config *catalog.Config) {
-				config.PluginConfigs[0].DataSource = catalog.FixedData("GOOD")
+				config.PluginConfigs[0].DataSource = catalog.FixedData{Data: "GOOD", Format: catalog.ConfigFormatHCL}
 			},
 			expectPluginClient:  true,
 			expectServiceClient: true,
@@ -233,7 +233,7 @@ func testPlugin(t *testing.T, pluginPath string) {
 		testLoad(t, pluginPath, loadTest{
 			registerConfigService: true,
 			mutateConfig: func(config *catalog.Config) {
-				config.PluginConfigs[0].DataSource = catalog.FileData(configPath)
+				config.PluginConfigs[0].DataSource = catalog.FileData{Path: configPath, Format: catalog.ConfigFormatHCL}
 			},
 			expectPluginClient:  true,
 			expectServiceClient: true,
@@ -263,7 +263,7 @@ func testPlugin(t *testing.T, pluginPath string) {
 		testLoad(t, pluginPath, loadTest{
 			registerConfigService: true,
 			mutateConfig: func(config *catalog.Config) {
-				config.PluginConfigs[0].DataSource = catalog.FixedData("BAD")
+				config.PluginConfigs[0].DataSource = catalog.FixedData{Data: "BAD", Format: catalog.ConfigFormatHCL}
 			},
 			expectErr: `failed to configure plugin "test": rpc error: code = InvalidArgument desc = bad config`,
 		})
@@ -271,7 +271,7 @@ func testPlugin(t *testing.T, pluginPath string) {
 	t.Run("configure interface not registered but data supplied", func(t *testing.T) {
 		testLoad(t, pluginPath, loadTest{
 			mutateConfig: func(config *catalog.Config) {
-				config.PluginConfigs[0].DataSource = catalog.FixedData("GOOD")
+				config.PluginConfigs[0].DataSource = catalog.FixedData{Data: "GOOD", Format: catalog.ConfigFormatHCL}
 			},
 			expectErr: `failed to configure plugin "test": no supported configuration interface found`,
 		})

--- a/pkg/common/catalog/config.go
+++ b/pkg/common/catalog/config.go
@@ -2,15 +2,36 @@ package catalog
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/hcl/hcl/token"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	yamlpkg "sigs.k8s.io/yaml"
 )
+
+// ConfigFormat identifies the serialization format of a plugin configuration string.
+type ConfigFormat int
+
+const (
+	ConfigFormatHCL  ConfigFormat = iota
+	ConfigFormatYAML
+)
+
+func (f ConfigFormat) ToProto() configv1.ConfigFormat {
+	switch f {
+	case ConfigFormatYAML:
+		return configv1.ConfigFormat_CONFIG_FORMAT_YAML
+	default:
+		return configv1.ConfigFormat_CONFIG_FORMAT_HCL
+	}
+}
 
 type PluginConfigs []PluginConfig
 
@@ -53,33 +74,35 @@ func (c *PluginConfig) IsExternal() bool {
 }
 
 type DataSource interface {
-	Load() (string, error)
+	Load() (string, ConfigFormat, error)
 	IsDynamic() bool
 }
 
-type FixedData string
-
-func (d FixedData) Load() (string, error) {
-	return string(d), nil
+type FixedData struct {
+	Data   string
+	Format ConfigFormat
 }
 
-func (d FixedData) IsDynamic() bool {
-	return false
+func (d FixedData) Load() (string, ConfigFormat, error) {
+	return d.Data, d.Format, nil
 }
 
-type FileData string
+func (d FixedData) IsDynamic() bool { return false }
 
-func (d FileData) Load() (string, error) {
-	data, err := os.ReadFile(string(d))
+type FileData struct {
+	Path   string
+	Format ConfigFormat
+}
+
+func (d FileData) Load() (string, ConfigFormat, error) {
+	data, err := os.ReadFile(d.Path)
 	if err != nil {
-		return "", err
+		return "", d.Format, err
 	}
-	return string(data), nil
+	return string(data), d.Format, nil
 }
 
-func (d FileData) IsDynamic() bool {
-	return true
-}
+func (d FileData) IsDynamic() bool { return true }
 
 type hclPluginConfig struct {
 	PluginCmd      string   `hcl:"plugin_cmd"`
@@ -262,12 +285,12 @@ func pluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig hclPlugi
 			return PluginConfig{}, err
 		}
 		if data := buf.String(); data != "" {
-			dataSource = FixedData(data)
+			dataSource = FixedData{Data: data, Format: ConfigFormatHCL}
 		}
 	}
 
 	if hclPluginConfig.PluginDataFile != nil {
-		dataSource = FileData(*hclPluginConfig.PluginDataFile)
+		dataSource = FileData{Path: *hclPluginConfig.PluginDataFile, Format: ConfigFormatHCL}
 	}
 
 	return PluginConfig{
@@ -278,6 +301,79 @@ func pluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig hclPlugi
 		Checksum:   hclPluginConfig.PluginChecksum,
 		DataSource: dataSource,
 		Disabled:   !hclPluginConfig.IsEnabled(),
+	}, nil
+}
+
+type yamlPluginConfig struct {
+	PluginCmd      string         `yaml:"pluginCmd"`
+	PluginArgs     []string       `yaml:"pluginArgs"`
+	PluginChecksum string         `yaml:"pluginChecksum"`
+	PluginData     map[string]any `yaml:"pluginData"`
+	PluginDataFile *string        `yaml:"pluginDataFile"`
+	Enabled        *bool          `yaml:"enabled"`
+}
+
+func (c yamlPluginConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// PluginConfigsFromYAML parses the plugins section from a YAML config.
+// YAML structure: plugins.<pluginType>.<pluginName>: <yamlPluginConfig>
+func PluginConfigsFromYAML(raw json.RawMessage) (PluginConfigs, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	var pluginsMap map[string]map[string]yamlPluginConfig
+	if err := json.Unmarshal(raw, &pluginsMap); err != nil {
+		return nil, fmt.Errorf("failed to decode YAML plugins config: %w", err)
+	}
+
+	var pluginConfigs PluginConfigs
+	for pluginType, pluginsForType := range pluginsMap {
+		for pluginName, ypc := range pluginsForType {
+			pc, err := pluginConfigFromYAML(pluginType, pluginName, ypc)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create plugin config for %q/%q: %w", pluginType, pluginName, err)
+			}
+			pluginConfigs = append(pluginConfigs, pc)
+		}
+	}
+	return pluginConfigs, nil
+}
+
+func pluginConfigFromYAML(pluginType, pluginName string, ypc yamlPluginConfig) (PluginConfig, error) {
+	if ypc.PluginData != nil && ypc.PluginDataFile != nil {
+		return PluginConfig{}, errors.New("only one of [pluginData, pluginDataFile] can be used")
+	}
+
+	var dataSource DataSource
+
+	if len(ypc.PluginData) > 0 {
+		yamlBytes, err := yamlpkg.Marshal(ypc.PluginData)
+		if err != nil {
+			return PluginConfig{}, fmt.Errorf("failed to re-marshal plugin data: %w", err)
+		}
+		if data := strings.TrimSpace(string(yamlBytes)); data != "" {
+			dataSource = FixedData{Data: data, Format: ConfigFormatYAML}
+		}
+	}
+
+	if ypc.PluginDataFile != nil {
+		dataSource = FileData{Path: *ypc.PluginDataFile, Format: ConfigFormatYAML}
+	}
+
+	return PluginConfig{
+		Name:       pluginName,
+		Type:       pluginType,
+		Path:       ypc.PluginCmd,
+		Args:       ypc.PluginArgs,
+		Checksum:   ypc.PluginChecksum,
+		DataSource: dataSource,
+		Disabled:   !ypc.IsEnabled(),
 	}, nil
 }
 

--- a/pkg/common/catalog/config_test.go
+++ b/pkg/common/catalog/config_test.go
@@ -1,10 +1,13 @@
 package catalog
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +29,7 @@ func TestParsePluginConfigsFromHCLNode(t *testing.T) {
 		pluginA := PluginConfig{
 			Name:       "NAME3",
 			Type:       "TYPE1",
-			DataSource: FixedData(`"DATA3"`),
+			DataSource: FixedData{Data: `"DATA3"`, Format: ConfigFormatHCL},
 			Disabled:   true,
 		}
 		pluginB := PluginConfig{
@@ -37,13 +40,13 @@ func TestParsePluginConfigsFromHCLNode(t *testing.T) {
 			Name:       "NAME1",
 			Type:       "TYPE1",
 			Path:       "CMD1",
-			DataSource: FixedData(`"DATA1"`),
+			DataSource: FixedData{Data: `"DATA1"`, Format: ConfigFormatHCL},
 			Disabled:   false,
 		}
 		pluginD := PluginConfig{
 			Name:       "NAME5",
 			Type:       "TYPE1",
-			DataSource: FixedData(`"foo" = "bar"`),
+			DataSource: FixedData{Data: `"foo" = "bar"`, Format: ConfigFormatHCL},
 			Disabled:   false,
 		}
 		pluginE := PluginConfig{
@@ -52,19 +55,19 @@ func TestParsePluginConfigsFromHCLNode(t *testing.T) {
 			Path:       "CMD2",
 			Args:       []string{"foo", "bar", "baz"},
 			Checksum:   "CHECKSUM2",
-			DataSource: FixedData(`"DATA2"`),
+			DataSource: FixedData{Data: `"DATA2"`, Format: ConfigFormatHCL},
 			Disabled:   false,
 		}
 		pluginF := PluginConfig{
 			Name:       "NAME6",
 			Type:       "TYPE3",
-			DataSource: FixedData(`"foo" = "bar"`),
+			DataSource: FixedData{Data: `"foo" = "bar"`, Format: ConfigFormatHCL},
 			Disabled:   false,
 		}
 		pluginG := PluginConfig{
 			Name:       "NAME7",
 			Type:       "TYPE5",
-			DataSource: FileData("FILE7"),
+			DataSource: FileData{Path: "FILE7", Format: ConfigFormatHCL},
 		}
 		pluginH := PluginConfig{
 			Name:       "NAME8",
@@ -271,4 +274,92 @@ func TestParsePluginConfigsFromHCLNode(t *testing.T) {
 		_, err = PluginConfigsFromHCLNode(root.Plugins)
 		require.EqualError(t, err, `failed to create plugin config for "TYPE"/"NAME": only one of [plugin_data, plugin_data_file] can be used`)
 	})
+}
+
+func TestConfigFormat_toProto(t *testing.T) {
+	require.Equal(t, configv1.ConfigFormat_CONFIG_FORMAT_HCL, ConfigFormatHCL.ToProto())
+	require.Equal(t, configv1.ConfigFormat_CONFIG_FORMAT_YAML, ConfigFormatYAML.ToProto())
+}
+
+func TestFixedData_Load(t *testing.T) {
+	d := FixedData{Data: "hello", Format: ConfigFormatYAML}
+	data, format, err := d.Load()
+	require.NoError(t, err)
+	require.Equal(t, "hello", data)
+	require.Equal(t, ConfigFormatYAML, format)
+}
+
+func TestPluginConfigsFromYAML(t *testing.T) {
+	raw := json.RawMessage(`{
+		"NodeAttestor": {
+			"k8s_psat": {
+				"pluginCmd": "./attestor",
+				"pluginChecksum": "abc123",
+				"pluginArgs": ["--arg1", "--arg2"],
+				"pluginData": {"cluster": "prod"},
+				"enabled": true
+			},
+			"disabled_plugin": {
+				"pluginCmd": "./attestor2",
+				"enabled": false
+			}
+		},
+		"KeyManager": {
+			"disk": {
+				"pluginDataFile": "keymanager.yaml"
+			}
+		}
+	}`)
+
+	configs, err := PluginConfigsFromYAML(raw)
+	require.NoError(t, err)
+	require.Len(t, configs, 3)
+
+	attestor, ok := configs.Find("NodeAttestor", "k8s_psat")
+	require.True(t, ok)
+	require.Equal(t, "./attestor", attestor.Path)
+	require.Equal(t, "abc123", attestor.Checksum)
+	require.Equal(t, []string{"--arg1", "--arg2"}, attestor.Args)
+	require.False(t, attestor.Disabled)
+	require.NotNil(t, attestor.DataSource)
+	data, format, err := attestor.DataSource.Load()
+	require.NoError(t, err)
+	require.Equal(t, ConfigFormatYAML, format)
+	require.Contains(t, data, "cluster")
+
+	disabled, ok := configs.Find("NodeAttestor", "disabled_plugin")
+	require.True(t, ok)
+	require.True(t, disabled.Disabled)
+
+	km, ok := configs.Find("KeyManager", "disk")
+	require.True(t, ok)
+	require.NotNil(t, km.DataSource)
+	_, format2, _ := km.DataSource.Load()
+	require.Equal(t, ConfigFormatYAML, format2)
+}
+
+func TestPluginConfigsFromYAML_Nil(t *testing.T) {
+	configs, err := PluginConfigsFromYAML(nil)
+	require.NoError(t, err)
+	require.Nil(t, configs)
+}
+
+func TestPluginConfigsFromYAML_BothDataSources(t *testing.T) {
+	raw := json.RawMessage(`{"T":{"n":{"pluginData":{"k":"v"},"pluginDataFile":"f.yaml"}}}`)
+	_, err := PluginConfigsFromYAML(raw)
+	require.ErrorContains(t, err, "only one of")
+}
+
+func TestFileData_Load(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "test*.yaml")
+	require.NoError(t, err)
+	_, err = f.WriteString("key: value")
+	require.NoError(t, err)
+	f.Close()
+
+	d := FileData{Path: f.Name(), Format: ConfigFormatYAML}
+	data, format, err := d.Load()
+	require.NoError(t, err)
+	require.Equal(t, "key: value", data)
+	require.Equal(t, ConfigFormatYAML, format)
 }

--- a/pkg/common/catalog/configure.go
+++ b/pkg/common/catalog/configure.go
@@ -26,15 +26,15 @@ func (c CoreConfig) v1() *configv1.CoreConfiguration {
 }
 
 type Configurer interface {
-	Configure(ctx context.Context, coreConfig CoreConfig, configuration string) error
+	Configure(ctx context.Context, coreConfig CoreConfig, configuration string, format ConfigFormat) error
 	Validate(ctx context.Context, coreConfig CoreConfig, configuration string) (*configv1.ValidateResponse, error)
 }
 
-type ConfigurerFunc func(ctx context.Context, coreConfig CoreConfig, configuration string) error
+type ConfigurerFunc func(ctx context.Context, coreConfig CoreConfig, configuration string, format ConfigFormat) error
 type ValidatorFunc func(ctx context.Context, coreConfig CoreConfig, configuration string) (*configv1.ValidateResponse, error)
 
-func (fn ConfigurerFunc) Configure(ctx context.Context, coreConfig CoreConfig, configuration string) error {
-	return fn(ctx, coreConfig, configuration)
+func (fn ConfigurerFunc) Configure(ctx context.Context, coreConfig CoreConfig, configuration string, format ConfigFormat) error {
+	return fn(ctx, coreConfig, configuration, format)
 }
 
 func (fn ValidatorFunc) Validate(ctx context.Context, coreConfig CoreConfig, configuration string) (*configv1.ValidateResponse, error) {
@@ -42,14 +42,14 @@ func (fn ValidatorFunc) Validate(ctx context.Context, coreConfig CoreConfig, con
 }
 
 func ConfigurePlugin(ctx context.Context, coreConfig CoreConfig, configurer Configurer, dataSource DataSource, lastHash string) (string, error) {
-	data, err := dataSource.Load()
+	data, format, err := dataSource.Load()
 	if err != nil {
 		return "", fmt.Errorf("failed to load plugin data: %w", err)
 	}
 
 	dataHash := hashData(data)
 	if lastHash == "" || dataHash != lastHash {
-		if err := configurer.Configure(ctx, coreConfig, data); err != nil {
+		if err := configurer.Configure(ctx, coreConfig, data, format); err != nil {
 			return "", err
 		}
 	}
@@ -103,7 +103,7 @@ func configurePlugin(ctx context.Context, pluginLog logrus.FieldLogger, coreConf
 		return nil, errors.New("no supported configuration interface found")
 	case configurer != nil && dataSource == nil:
 		// The plugin supports configuration but no data source was configured. Default to an empty, fixed configuration.
-		dataSource = FixedData("")
+		dataSource = FixedData{Data: "", Format: ConfigFormatHCL}
 	case configurer != nil && dataSource != nil:
 		// The plugin supports configuration and there was a data source.
 	}
@@ -168,11 +168,16 @@ func (v1 *configurerV1) InitInfo(PluginInfo) {
 func (v1 *configurerV1) InitLog(logrus.FieldLogger) {
 }
 
-func (v1 *configurerV1) Configure(ctx context.Context, coreConfig CoreConfig, hclConfiguration string) error {
-	_, err := v1.ConfigServiceClient.Configure(ctx, &configv1.ConfigureRequest{
+func (v1 *configurerV1) Configure(ctx context.Context, coreConfig CoreConfig, configuration string, format ConfigFormat) error {
+	req := &configv1.ConfigureRequest{
 		CoreConfiguration: coreConfig.v1(),
-		HclConfiguration:  hclConfiguration,
-	})
+		Configuration:     configuration,
+		ConfigFormat:      format.ToProto(),
+	}
+	if format == ConfigFormatHCL {
+		req.HclConfiguration = configuration
+	}
+	_, err := v1.ConfigServiceClient.Configure(ctx, req)
 	return err
 }
 

--- a/pkg/common/plugin/sshpop/sshpop.go
+++ b/pkg/common/plugin/sshpop/sshpop.go
@@ -7,14 +7,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
 	"golang.org/x/crypto/ssh"
 )
+
+var _ pluginconf.Request = (*ClientConfigRequest)(nil)
+var _ pluginconf.Request = (*ServerConfigRequest)(nil)
 
 const (
 	// PluginName is used for identifying this plugin type for protobuf blobs.
@@ -54,8 +57,8 @@ type Server struct {
 
 // ClientConfig configures the client.
 type ClientConfig struct {
-	HostKeyPath  string `hcl:"host_key_path"`
-	HostCertPath string `hcl:"host_cert_path"`
+	HostKeyPath  string `hcl:"host_key_path" yaml:"hostKeyPath"`
+	HostCertPath string `hcl:"host_cert_path" yaml:"hostCertPath"`
 
 	cert   *ssh.Certificate
 	signer ssh.Signer
@@ -74,6 +77,11 @@ func (ccr *ClientConfigRequest) GetHclConfiguration() string {
 	return ccr.hclText
 }
 
+func (ccr *ClientConfigRequest) GetConfiguration() string { return "" }
+func (ccr *ClientConfigRequest) GetConfigFormat() configv1.ConfigFormat {
+	return configv1.ConfigFormat_CONFIG_FORMAT_HCL
+}
+
 type ServerConfigRequest struct {
 	coreConfig *configv1.CoreConfiguration
 	hclText    string
@@ -87,23 +95,28 @@ func (scr *ServerConfigRequest) GetHclConfiguration() string {
 	return scr.hclText
 }
 
+func (scr *ServerConfigRequest) GetConfiguration() string { return "" }
+func (scr *ServerConfigRequest) GetConfigFormat() configv1.ConfigFormat {
+	return configv1.ConfigFormat_CONFIG_FORMAT_HCL
+}
+
 // ServerConfig configures the server.
 type ServerConfig struct {
-	CertAuthorities     []string `hcl:"cert_authorities"`
-	CertAuthoritiesPath string   `hcl:"cert_authorities_path"`
+	CertAuthorities     []string `hcl:"cert_authorities" yaml:"certAuthorities"`
+	CertAuthoritiesPath string   `hcl:"cert_authorities_path" yaml:"certAuthoritiesPath"`
 	// CanonicalDomain specifies the domain suffix for validating the hostname against
 	// the certificate's valid principals. See CanonicalDomains in ssh_config(5).
-	CanonicalDomain   string `hcl:"canonical_domain"`
-	AgentPathTemplate string `hcl:"agent_path_template"`
+	CanonicalDomain   string `hcl:"canonical_domain" yaml:"canonicalDomain"`
+	AgentPathTemplate string `hcl:"agent_path_template" yaml:"agentPathTemplate"`
 
 	certChecker       *ssh.CertChecker
 	agentPathTemplate *agentpathtemplate.Template
 	trustDomain       spiffeid.TrustDomain
 }
 
-func BuildServerConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *ServerConfig {
+func BuildServerConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *ServerConfig {
 	newConfig := new(ServerConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("failed to decode configuration: %v", err)
 		return nil
 	}
@@ -153,9 +166,9 @@ func (sc *ServerConfig) NewServer() *Server {
 	}
 }
 
-func BuildClientConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *ClientConfig {
+func BuildClientConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *ClientConfig {
 	newConfig := new(ClientConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("failed to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/common/pluginconf/pluginconf.go
+++ b/pkg/common/pluginconf/pluginconf.go
@@ -2,7 +2,7 @@ package pluginconf
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/hcl/token"
@@ -13,8 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ReportUnusedKeys reports an error on s listing any keys present in
-// unused. If unused is empty, no error is reported.
+// ReportUnusedKeys reports an error on s listing any keys present in unused.
 func ReportUnusedKeys(s *Status, unused map[string][]token.Pos) {
 	if len(unused) == 0 {
 		return
@@ -23,7 +22,7 @@ func ReportUnusedKeys(s *Status, unused map[string][]token.Pos) {
 	for k := range unused {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	s.ReportErrorf("unknown configurations detected: %s", strings.Join(keys, ","))
 }
 
@@ -54,9 +53,29 @@ func (s *Status) ReportErrorf(format string, args ...any) {
 type Request interface {
 	GetCoreConfiguration() *configv1.CoreConfiguration
 	GetHclConfiguration() string
+	GetConfiguration() string
+	GetConfigFormat() configv1.ConfigFormat
 }
 
-func Build[C any](req Request, build func(coreConfig catalog.CoreConfig, hclText string, s *Status) *C) (*C, []string, error) {
+// configText returns the configuration text from the request, preferring
+// the new Configuration field over the legacy HclConfiguration field.
+func configText(req Request) string {
+	if c := req.GetConfiguration(); c != "" {
+		return c
+	}
+	return req.GetHclConfiguration()
+}
+
+// configFormat returns the ConfigFormat from the request, defaulting to HCL
+// when the new field is unset (old SPIRE sending only hcl_configuration).
+func configFormat(req Request) catalog.ConfigFormat {
+	if req.GetConfigFormat() == configv1.ConfigFormat_CONFIG_FORMAT_YAML {
+		return catalog.ConfigFormatYAML
+	}
+	return catalog.ConfigFormatHCL
+}
+
+func Build[C any](req Request, build func(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, s *Status) *C) (*C, []string, error) {
 	var s Status
 	var coreConfig catalog.CoreConfig
 
@@ -75,6 +94,6 @@ func Build[C any](req Request, build func(coreConfig catalog.CoreConfig, hclText
 		}
 	}
 
-	config := build(coreConfig, req.GetHclConfiguration(), &s)
+	config := build(coreConfig, configText(req), configFormat(req), &s)
 	return config, s.notes, s.err
 }

--- a/pkg/common/plugindecode/decode.go
+++ b/pkg/common/plugindecode/decode.go
@@ -1,0 +1,18 @@
+package plugindecode
+
+import (
+	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"sigs.k8s.io/yaml"
+)
+
+// DecodeConfig decodes text into out using the given format.
+// For HCL, uses hashicorp/hcl. For YAML, uses sigs.k8s.io/yaml.
+func DecodeConfig(text string, format catalog.ConfigFormat, out any) error {
+	switch format {
+	case catalog.ConfigFormatYAML:
+		return yaml.Unmarshal([]byte(text), out)
+	default:
+		return hcl.Decode(out, text)
+	}
+}

--- a/pkg/common/plugindecode/decode_test.go
+++ b/pkg/common/plugindecode/decode_test.go
@@ -1,0 +1,58 @@
+package plugindecode_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
+	"github.com/stretchr/testify/require"
+)
+
+type testConfig struct {
+	KeysPath  string `hcl:"keys_path"  yaml:"keysPath"`
+	MaxKeys   int    `hcl:"max_keys"   yaml:"maxKeys"`
+}
+
+func TestDecodeConfig_HCL(t *testing.T) {
+	hclText := `keys_path = "/tmp/keys"
+max_keys = 10`
+	var cfg testConfig
+	err := plugindecode.DecodeConfig(hclText, catalog.ConfigFormatHCL, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/keys", cfg.KeysPath)
+	require.Equal(t, 10, cfg.MaxKeys)
+}
+
+func TestDecodeConfig_YAML(t *testing.T) {
+	yamlText := `keysPath: /tmp/keys
+maxKeys: 10`
+	var cfg testConfig
+	err := plugindecode.DecodeConfig(yamlText, catalog.ConfigFormatYAML, &cfg)
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/keys", cfg.KeysPath)
+	require.Equal(t, 10, cfg.MaxKeys)
+}
+
+func TestDecodeConfig_EmptyHCL(t *testing.T) {
+	var cfg testConfig
+	err := plugindecode.DecodeConfig("", catalog.ConfigFormatHCL, &cfg)
+	require.NoError(t, err)
+}
+
+func TestDecodeConfig_EmptyYAML(t *testing.T) {
+	var cfg testConfig
+	err := plugindecode.DecodeConfig("", catalog.ConfigFormatYAML, &cfg)
+	require.NoError(t, err)
+}
+
+func TestDecodeConfig_InvalidHCL(t *testing.T) {
+	var cfg testConfig
+	err := plugindecode.DecodeConfig("not { valid hcl !!!", catalog.ConfigFormatHCL, &cfg)
+	require.Error(t, err)
+}
+
+func TestDecodeConfig_InvalidYAML(t *testing.T) {
+	var cfg testConfig
+	err := plugindecode.DecodeConfig(":\n  - bad: [yaml", catalog.ConfigFormatYAML, &cfg)
+	require.Error(t, err)
+}

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/datastore"
@@ -819,7 +820,7 @@ func newSQLPlugin(ctx context.Context, tb testing.TB) datastore.DataStore {
 		require.FailNowf(tb, "Unsupported external test dialect %q", TestDialect)
 	}
 
-	err := p.Configure(ctx, cfg)
+	err := p.Configure(ctx, cfg, catalog.ConfigFormatHCL)
 	require.NoError(tb, err)
 
 	return p

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -90,8 +90,8 @@ type dsConfigurer struct {
 	ds *ds_sql.Plugin
 }
 
-func (c *dsConfigurer) Configure(ctx context.Context, _ catalog.CoreConfig, configuration string) error {
-	return c.ds.Configure(ctx, configuration)
+func (c *dsConfigurer) Configure(ctx context.Context, _ catalog.CoreConfig, configuration string, format catalog.ConfigFormat) error {
+	return c.ds.Configure(ctx, configuration, format)
 }
 
 func (c *dsConfigurer) Validate(ctx context.Context, coreConfig catalog.CoreConfig, configuration string) (*configv1.ValidateResponse, error) {
@@ -268,7 +268,7 @@ func loadSQLDataStore(ctx context.Context, config Config, coreConfig catalog.Cor
 		return nil, fmt.Errorf("pluggability for the DataStore is deprecated; only the built-in %q plugin is supported", ds_sql.PluginName)
 	}
 	if sqlConfig.DataSource == nil {
-		sqlConfig.DataSource = catalog.FixedData("")
+		sqlConfig.DataSource = catalog.FixedData{Data: "", Format: catalog.ConfigFormatHCL}
 	}
 
 	dsLog := config.Log.WithField(telemetry.SubsystemName, sqlConfig.Name)

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -55,10 +55,13 @@ func Test(t *testing.T) {
 					{
 						Type: "DataStore",
 						Name: "sql",
-						DataSource: commoncatalog.FixedData(fmt.Sprintf(`
+						DataSource: commoncatalog.FixedData{
+						Data: fmt.Sprintf(`
 						database_type = "sqlite3"
 						connection_string = %q
-					`, filepath.Join(dir, "test.sql"))),
+					`, filepath.Join(dir, "test.sql")),
+						Format: commoncatalog.ConfigFormatHCL,
+					},
 					},
 					{
 						Type: "KeyManager",

--- a/pkg/server/common/vault/configuration.go
+++ b/pkg/server/common/vault/configuration.go
@@ -7,68 +7,68 @@ import (
 
 type BaseConfiguration struct {
 	// A URL of Vault server. (e.g., https://vault.example.com:8443/)
-	VaultAddr string `hcl:"vault_addr" json:"vault_addr"`
+	VaultAddr string `hcl:"vault_addr" json:"vault_addr" yaml:"vaultAddr"`
 	// Configuration for the Token authentication method
-	TokenAuth *TokenAuthConfig `hcl:"token_auth" json:"token_auth,omitempty"`
+	TokenAuth *TokenAuthConfig `hcl:"token_auth" json:"token_auth,omitempty" yaml:"tokenAuth,omitempty"`
 	// Configuration for the Client Certificate authentication method
-	CertAuth *CertAuthConfig `hcl:"cert_auth" json:"cert_auth,omitempty"`
+	CertAuth *CertAuthConfig `hcl:"cert_auth" json:"cert_auth,omitempty" yaml:"certAuth,omitempty"`
 	// Configuration for the AppRole authentication method
-	AppRoleAuth *AppRoleAuthConfig `hcl:"approle_auth" json:"approle_auth,omitempty"`
+	AppRoleAuth *AppRoleAuthConfig `hcl:"approle_auth" json:"approle_auth,omitempty" yaml:"approleAuth,omitempty"`
 	// Configuration for the Kubernetes authentication method
-	K8sAuth *K8sAuthConfig `hcl:"k8s_auth" json:"k8s_auth,omitempty"`
+	K8sAuth *K8sAuthConfig `hcl:"k8s_auth" json:"k8s_auth,omitempty" yaml:"k8sAuth,omitempty"`
 	// Path to a CA certificate file that the client verifies the server certificate.
 	// Only PEM format is supported.
-	CACertPath string `hcl:"ca_cert_path" json:"ca_cert_path"`
+	CACertPath string `hcl:"ca_cert_path" json:"ca_cert_path" yaml:"caCertPath"`
 	// If true, vault client accepts any server certificates.
 	// It should be used only test environment so on.
-	InsecureSkipVerify bool `hcl:"insecure_skip_verify" json:"insecure_skip_verify"`
+	InsecureSkipVerify bool `hcl:"insecure_skip_verify" json:"insecure_skip_verify" yaml:"insecureSkipVerify"`
 	// Name of the Vault namespace
-	Namespace string `hcl:"namespace" json:"namespace"`
+	Namespace string `hcl:"namespace" json:"namespace" yaml:"namespace"`
 }
 
 // TokenAuthConfig represents parameters for token auth method
 type TokenAuthConfig struct {
 	// Token string to set into "X-Vault-Token" header
-	Token string `hcl:"token" json:"token"`
+	Token string `hcl:"token" json:"token" yaml:"token"`
 }
 
 // CertAuthConfig represents parameters for cert auth method
 type CertAuthConfig struct {
 	// Name of the mount point where Client Certificate Auth method is mounted. (e.g., /auth/<mount_point>/login)
 	// If the value is empty, use default mount point (/auth/cert)
-	CertAuthMountPoint string `hcl:"cert_auth_mount_point" json:"cert_auth_mount_point"`
+	CertAuthMountPoint string `hcl:"cert_auth_mount_point" json:"cert_auth_mount_point" yaml:"certAuthMountPoint"`
 	// Name of the Vault role.
 	// If given, the plugin authenticates against only the named role.
-	CertAuthRoleName string `hcl:"cert_auth_role_name" json:"cert_auth_role_name"`
+	CertAuthRoleName string `hcl:"cert_auth_role_name" json:"cert_auth_role_name" yaml:"certAuthRoleName"`
 	// Path to a client certificate file.
 	// Only PEM format is supported.
-	ClientCertPath string `hcl:"client_cert_path" json:"client_cert_path"`
+	ClientCertPath string `hcl:"client_cert_path" json:"client_cert_path" yaml:"clientCertPath"`
 	// Path to a client private key file.
 	// Only PEM format is supported.
-	ClientKeyPath string `hcl:"client_key_path" json:"client_key_path"`
+	ClientKeyPath string `hcl:"client_key_path" json:"client_key_path" yaml:"clientKeyPath"`
 }
 
 // AppRoleAuthConfig represents parameters for AppRole auth method.
 type AppRoleAuthConfig struct {
 	// Name of the mount point where AppRole auth method is mounted. (e.g., /auth/<mount_point>/login)
 	// If the value is empty, use default mount point (/auth/approle)
-	AppRoleMountPoint string `hcl:"approle_auth_mount_point" json:"approle_auth_mount_point"`
+	AppRoleMountPoint string `hcl:"approle_auth_mount_point" json:"approle_auth_mount_point" yaml:"approleAuthMountPoint"`
 	// An identifier that selects the AppRole
-	RoleID string `hcl:"approle_id" json:"approle_id"`
+	RoleID string `hcl:"approle_id" json:"approle_id" yaml:"approleID"`
 	// A credential that is required for login.
-	SecretID string `hcl:"approle_secret_id" json:"approle_secret_id"`
+	SecretID string `hcl:"approle_secret_id" json:"approle_secret_id" yaml:"approleSecretID"`
 }
 
 // K8sAuthConfig represents parameters for Kubernetes auth method.
 type K8sAuthConfig struct {
 	// Name of the mount point where Kubernetes auth method is mounted. (e.g., /auth/<mount_point>/login)
 	// If the value is empty, use default mount point (/auth/kubernetes)
-	K8sAuthMountPoint string `hcl:"k8s_auth_mount_point" json:"k8s_auth_mount_point"`
+	K8sAuthMountPoint string `hcl:"k8s_auth_mount_point" json:"k8s_auth_mount_point" yaml:"k8sAuthMountPoint"`
 	// Name of the Vault role.
 	// The plugin authenticates against the named role.
-	K8sAuthRoleName string `hcl:"k8s_auth_role_name" json:"k8s_auth_role_name"`
+	K8sAuthRoleName string `hcl:"k8s_auth_role_name" json:"k8s_auth_role_name" yaml:"k8sAuthRoleName"`
 	// Path to the Kubernetes Service Account Token to use authentication with the Vault.
-	TokenPath string `hcl:"token_path" json:"token_path"`
+	TokenPath string `hcl:"token_path" json:"token_path" yaml:"tokenPath"`
 }
 
 func GenClientParams(method AuthMethod, baseConfig *BaseConfiguration, lookupEnv func(string) (string, bool)) (*ClientParams, error) {

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -27,6 +27,7 @@ import (
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
@@ -75,20 +76,20 @@ const (
 // Configuration for the sql datastore implementation.
 // Pointer values are used to distinguish between "unset" and "zero" values.
 type configuration struct {
-	DatabaseTypeNode   ast.Node `hcl:"database_type" json:"database_type"`
-	ConnectionString   string   `hcl:"connection_string" json:"connection_string"`
-	RoConnectionString string   `hcl:"ro_connection_string" json:"ro_connection_string"`
-	RootCAPath         string   `hcl:"root_ca_path" json:"root_ca_path"`
-	ClientCertPath     string   `hcl:"client_cert_path" json:"client_cert_path"`
-	ClientKeyPath      string   `hcl:"client_key_path" json:"client_key_path"`
-	ConnMaxLifetime    *string  `hcl:"conn_max_lifetime" json:"conn_max_lifetime"`
-	MaxOpenConns       *int     `hcl:"max_open_conns" json:"max_open_conns"`
-	MaxIdleConns       *int     `hcl:"max_idle_conns" json:"max_idle_conns"`
-	DisableMigration   bool     `hcl:"disable_migration" json:"disable_migration"`
+	DatabaseTypeNode   ast.Node `hcl:"database_type"        json:"database_type"        yaml:"databaseType"`
+	ConnectionString   string   `hcl:"connection_string"    json:"connection_string"    yaml:"connectionString"`
+	RoConnectionString string   `hcl:"ro_connection_string" json:"ro_connection_string" yaml:"roConnectionString"`
+	RootCAPath         string   `hcl:"root_ca_path"         json:"root_ca_path"         yaml:"rootCaPath"`
+	ClientCertPath     string   `hcl:"client_cert_path"     json:"client_cert_path"     yaml:"clientCertPath"`
+	ClientKeyPath      string   `hcl:"client_key_path"      json:"client_key_path"      yaml:"clientKeyPath"`
+	ConnMaxLifetime    *string  `hcl:"conn_max_lifetime"    json:"conn_max_lifetime"    yaml:"connMaxLifetime"`
+	MaxOpenConns       *int     `hcl:"max_open_conns"       json:"max_open_conns"       yaml:"maxOpenConns"`
+	MaxIdleConns       *int     `hcl:"max_idle_conns"       json:"max_idle_conns"       yaml:"maxIdleConns"`
+	DisableMigration   bool     `hcl:"disable_migration"    json:"disable_migration"    yaml:"disableMigration"`
 
 	databaseTypeConfig *dbTypeConfig
 	// Undocumented flags
-	LogSQL bool `hcl:"log_sql" json:"log_sql"`
+	LogSQL bool `hcl:"log_sql" json:"log_sql" yaml:"logSQL"`
 }
 
 type dbTypeConfig struct {
@@ -849,11 +850,11 @@ checkAuthorities:
 	return nil
 }
 
-// Configure parses HCL config payload into config struct, opens new DB based on the result, and
+// Configure parses config payload into config struct, opens new DB based on the result, and
 // prunes all orphaned records
-func (ds *Plugin) Configure(ctx context.Context, hclConfiguration string) error {
+func (ds *Plugin) Configure(ctx context.Context, configText string, format catalog.ConfigFormat) error {
 	config := &configuration{}
-	if err := hcl.Decode(config, hclConfiguration); err != nil {
+	if err := plugindecode.DecodeConfig(configText, format, config); err != nil {
 		return err
 	}
 
@@ -872,7 +873,8 @@ func (ds *Plugin) Configure(ctx context.Context, hclConfiguration string) error 
 }
 
 func (ds *Plugin) Validate(ctx context.Context, coreConfig catalog.CoreConfig, configuration string) (*configv1.ValidateResponse, error) {
-	config, err := buildConfig(configuration)
+	// TODO: thread format through Validate interface in a follow-up
+	config, err := buildConfig(configuration, catalog.ConfigFormatHCL)
 	if err != nil {
 		return &configv1.ValidateResponse{
 			Notes: []string{err.Error()},
@@ -890,9 +892,9 @@ func (ds *Plugin) Validate(ctx context.Context, coreConfig catalog.CoreConfig, c
 	}, nil
 }
 
-func buildConfig(hclConfiguration string) (*configuration, error) {
+func buildConfig(configText string, format catalog.ConfigFormat) (*configuration, error) {
 	config := &configuration{}
-	if err := hcl.Decode(config, hclConfiguration); err != nil {
+	if err := plugindecode.DecodeConfig(configText, format, config); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/util"
@@ -133,7 +134,7 @@ func (s *PluginSuite) newPlugin() *Plugin {
 			database_type = "sqlite3"
 			log_sql = true
 			connection_string = "%s"
-		`, dbPath))
+		`, dbPath), catalog.ConfigFormatHCL)
 		s.Require().NoError(err)
 
 		// assert that WAL journal mode is enabled
@@ -158,7 +159,7 @@ func (s *PluginSuite) newPlugin() *Plugin {
 			log_sql = true
 			connection_string = "%s"
 			ro_connection_string = "%s"
-		`, TestConnString, TestROConnString))
+		`, TestConnString, TestROConnString), catalog.ConfigFormatHCL)
 		s.Require().NoError(err)
 	case "postgres":
 		s.T().Logf("CONN STRING: %q", TestConnString)
@@ -169,7 +170,7 @@ func (s *PluginSuite) newPlugin() *Plugin {
 			log_sql = true
 			connection_string = "%s"
 			ro_connection_string = "%s"
-		`, TestConnString, TestROConnString))
+		`, TestConnString, TestROConnString), catalog.ConfigFormatHCL)
 		s.Require().NoError(err)
 	default:
 		s.Require().FailNowf("Unsupported external test dialect %q", TestDialect)
@@ -182,7 +183,7 @@ func (s *PluginSuite) TestInvalidPluginConfiguration() {
 	err := s.ds.Configure(ctx, `
 		database_type = "wrong"
 		connection_string = "bad"
-	`)
+	`, catalog.ConfigFormatHCL)
 	s.RequireErrorContains(err, "datastore-sql: unsupported database_type: wrong")
 }
 
@@ -209,7 +210,7 @@ func (s *PluginSuite) TestInvalidAWSConfiguration() {
 	}
 	for _, testCase := range testCases {
 		s.T().Run(testCase.name, func(t *testing.T) {
-			err := s.ds.Configure(ctx, testCase.config)
+			err := s.ds.Configure(ctx, testCase.config, catalog.ConfigFormatHCL)
 			s.RequireErrorContains(err, testCase.expectedErr)
 		})
 	}
@@ -219,18 +220,18 @@ func (s *PluginSuite) TestInvalidMySQLConfiguration() {
 	err := s.ds.Configure(ctx, `
 		database_type = "mysql"
 		connection_string = "username:@tcp(127.0.0.1)/spire_test"
-	`)
+	`, catalog.ConfigFormatHCL)
 	s.RequireErrorContains(err, "datastore-sql: invalid mysql config: missing parseTime=true param in connection_string")
 
 	err = s.ds.Configure(ctx, `
 		database_type = "mysql"
 		ro_connection_string = "username:@tcp(127.0.0.1)/spire_test"
-	`)
+	`, catalog.ConfigFormatHCL)
 	s.RequireErrorContains(err, "datastore-sql: connection_string must be set")
 
 	err = s.ds.Configure(ctx, `
 		database_type = "mysql"
-	`)
+	`, catalog.ConfigFormatHCL)
 	s.RequireErrorContains(err, "datastore-sql: connection_string must be set")
 }
 
@@ -5226,7 +5227,7 @@ func (s *PluginSuite) TestMigration() {
 				err := s.ds.Configure(ctx, fmt.Sprintf(`
 					database_type = "sqlite3"
 					connection_string = %q
-				`, dbURI))
+				`, dbURI), catalog.ConfigFormatHCL)
 				if migrationSupported {
 					require.NoError(err)
 				} else {
@@ -5570,7 +5571,7 @@ func (s *PluginSuite) TestConfigure() {
 				log_sql = true
 				connection_string = "%s"
 				%s
-			`, dbPath, tt.giveDBConfig))
+			`, dbPath, tt.giveDBConfig), catalog.ConfigFormatHCL)
 			require.NoError(t, err)
 			defer p.Close()
 

--- a/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere.go
+++ b/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere.go
@@ -8,13 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rolesanywhere"
 	rolesanywheretypes "github.com/aws/aws-sdk-go-v2/service/rolesanywhere/types"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk/support/bundleformat"
 	bundlepublisherv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/bundlepublisher/v1"
 	"github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -38,15 +38,15 @@ func New() *Plugin {
 
 // Config holds the configuration of the plugin.
 type Config struct {
-	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id"`
-	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key"`
-	Region          string `hcl:"region" json:"region"`
-	TrustAnchorID   string `hcl:"trust_anchor_id" json:"trust_anchor_id"`
+	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key" yaml:"secretAccessKey"`
+	Region          string `hcl:"region" json:"region" yaml:"region"`
+	TrustAnchorID   string `hcl:"trust_anchor_id" json:"trust_anchor_id" yaml:"trustAnchorID"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/bundlepublisher/awss3/awss3.go
+++ b/pkg/server/plugin/bundlepublisher/awss3/awss3.go
@@ -9,13 +9,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk/support/bundleformat"
 	bundlepublisherv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/bundlepublisher/v1"
 	"github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/server/plugin/bundlepublisher/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,14 +40,14 @@ func New() *Plugin {
 
 // Config holds the configuration of the plugin.
 type Config struct {
-	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id"`
-	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key"`
-	Region          string `hcl:"region" json:"region"`
-	Bucket          string `hcl:"bucket" json:"bucket"`
-	ObjectKey       string `hcl:"object_key" json:"object_key"`
-	Format          string `hcl:"format" json:"format"`
-	Endpoint        string `hcl:"endpoint" json:"endpoint"`
-	RefreshHint     string `hcl:"refresh_hint" json:"refresh_hint"`
+	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key" yaml:"secretAccessKey"`
+	Region          string `hcl:"region" json:"region" yaml:"region"`
+	Bucket          string `hcl:"bucket" json:"bucket" yaml:"bucket"`
+	ObjectKey       string `hcl:"object_key" json:"object_key" yaml:"objectKey"`
+	Format          string `hcl:"format" json:"format" yaml:"format"`
+	Endpoint        string `hcl:"endpoint" json:"endpoint" yaml:"endpoint"`
+	RefreshHint     string `hcl:"refresh_hint" json:"refresh_hint" yaml:"refreshHint"`
 
 	// bundleFormat is used to store the content of Format, parsed
 	// as bundleformat.Format.
@@ -58,10 +58,10 @@ type Config struct {
 	parsedRefreshHint int64
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage.go
+++ b/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage.go
@@ -7,13 +7,13 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk/support/bundleformat"
 	bundlepublisherv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/bundlepublisher/v1"
 	"github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/plugin/bundlepublisher/common"
 	"google.golang.org/api/option"
@@ -42,11 +42,11 @@ func New() *Plugin {
 
 // Config holds the configuration of the plugin.
 type Config struct {
-	BucketName         string `hcl:"bucket_name" json:"bucket_name"`
-	ObjectName         string `hcl:"object_name" json:"object_name"`
-	Format             string `hcl:"format" json:"format"`
-	ServiceAccountFile string `hcl:"service_account_file" json:"service_account_file"`
-	RefreshHint        string `hcl:"refresh_hint" json:"refresh_hint"`
+	BucketName         string `hcl:"bucket_name" json:"bucket_name" yaml:"bucketName"`
+	ObjectName         string `hcl:"object_name" json:"object_name" yaml:"objectName"`
+	Format             string `hcl:"format" json:"format" yaml:"format"`
+	ServiceAccountFile string `hcl:"service_account_file" json:"service_account_file" yaml:"serviceAccountFile"`
+	RefreshHint        string `hcl:"refresh_hint" json:"refresh_hint" yaml:"refreshHint"`
 
 	// bundleFormat is used to store the content of Format, parsed
 	// as bundleformat.Format.
@@ -57,10 +57,10 @@ type Config struct {
 	parsedRefreshHint int64
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/bundlepublisher/k8sconfigmap/k8sconfigmap.go
+++ b/pkg/server/plugin/bundlepublisher/k8sconfigmap/k8sconfigmap.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk/support/bundleformat"
 	bundlepublisherv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/bundlepublisher/v1"
 	"github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/server/plugin/bundlepublisher/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,17 +40,17 @@ func New() *Plugin {
 
 // Config holds the configuration of the plugin.
 type Config struct {
-	Clusters map[string]*Cluster `hcl:"clusters,block" json:"clusters"`
+	Clusters map[string]*Cluster `hcl:"clusters,block" json:"clusters" yaml:"clusters"`
 }
 
-// Config holds the configuration of the plugin.
+// Cluster holds the configuration for a single cluster.
 type Cluster struct {
-	Format         string `hcl:"format" json:"format"`
-	Namespace      string `hcl:"namespace" json:"namespace"`
-	ConfigMapName  string `hcl:"configmap_name" json:"configmap_name"`
-	ConfigMapKey   string `hcl:"configmap_key" json:"configmap_key"`
-	KubeConfigPath string `hcl:"kubeconfig_path" json:"kubeconfig_path"`
-	RefreshHint    string `hcl:"refresh_hint" json:"refresh_hint"`
+	Format         string `hcl:"format" json:"format" yaml:"format"`
+	Namespace      string `hcl:"namespace" json:"namespace" yaml:"namespace"`
+	ConfigMapName  string `hcl:"configmap_name" json:"configmap_name" yaml:"configMapName"`
+	ConfigMapKey   string `hcl:"configmap_key" json:"configmap_key" yaml:"configMapKey"`
+	KubeConfigPath string `hcl:"kubeconfig_path" json:"kubeconfig_path" yaml:"kubeConfigPath"`
+	RefreshHint    string `hcl:"refresh_hint" json:"refresh_hint" yaml:"refreshHint"`
 
 	// bundleFormat is used to store the content of BundleFormat, parsed
 	// as bundleformat.Format.
@@ -65,11 +65,11 @@ type Cluster struct {
 	parsedRefreshHint int64
 }
 
-// buildConfig builds the plugin configuration from the provided HCL config.
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+// buildConfig builds the plugin configuration from the provided config text.
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -20,12 +20,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -100,18 +100,18 @@ type Plugin struct {
 
 // Config provides configuration context for the plugin
 type Config struct {
-	AccessKeyID        string            `hcl:"access_key_id" json:"access_key_id"`
-	SecretAccessKey    string            `hcl:"secret_access_key" json:"secret_access_key"`
-	Region             string            `hcl:"region" json:"region"`
-	KeyIdentifierFile  string            `hcl:"key_identifier_file" json:"key_identifier_file"`
-	KeyIdentifierValue string            `hcl:"key_identifier_value" json:"key_identifier_value"`
-	KeyPolicyFile      string            `hcl:"key_policy_file" json:"key_policy_file"`
-	KeyTags            map[string]string `hcl:"key_tags" json:"key_tags"`
+	AccessKeyID        string            `hcl:"access_key_id" json:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey    string            `hcl:"secret_access_key" json:"secret_access_key" yaml:"secretAccessKey"`
+	Region             string            `hcl:"region" json:"region" yaml:"region"`
+	KeyIdentifierFile  string            `hcl:"key_identifier_file" json:"key_identifier_file" yaml:"keyIdentifierFile"`
+	KeyIdentifierValue string            `hcl:"key_identifier_value" json:"key_identifier_value" yaml:"keyIdentifierValue"`
+	KeyPolicyFile      string            `hcl:"key_policy_file" json:"key_policy_file" yaml:"keyPolicyFile"`
+	KeyTags            map[string]string `hcl:"key_tags" json:"key_tags" yaml:"keyTags"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
@@ -22,12 +22,12 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 	"google.golang.org/grpc/codes"
@@ -78,19 +78,19 @@ type pluginHooks struct {
 
 // Config provides configuration context for the plugin.
 type Config struct {
-	KeyIdentifierFile  string `hcl:"key_identifier_file" json:"key_identifier_file"`
-	KeyIdentifierValue string `hcl:"key_identifier_value" json:"key_identifier_value"`
-	KeyVaultURI        string `hcl:"key_vault_uri" json:"key_vault_uri"`
-	TenantID           string `hcl:"tenant_id" json:"tenant_id"`
-	SubscriptionID     string `hcl:"subscription_id" json:"subscription_id"`
-	AppID              string `hcl:"app_id" json:"app_id"`
-	AppSecret          string `hcl:"app_secret" json:"app_secret"`
+	KeyIdentifierFile  string `hcl:"key_identifier_file" json:"key_identifier_file" yaml:"keyIdentifierFile"`
+	KeyIdentifierValue string `hcl:"key_identifier_value" json:"key_identifier_value" yaml:"keyIdentifierValue"`
+	KeyVaultURI        string `hcl:"key_vault_uri" json:"key_vault_uri" yaml:"keyVaultURI"`
+	TenantID           string `hcl:"tenant_id" json:"tenant_id" yaml:"tenantID"`
+	SubscriptionID     string `hcl:"subscription_id" json:"subscription_id" yaml:"subscriptionID"`
+	AppID              string `hcl:"app_id" json:"app_id" yaml:"appID"`
+	AppSecret          string `hcl:"app_secret" json:"app_secret" yaml:"appSecret"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/keymanager/disk/disk.go
+++ b/pkg/server/plugin/keymanager/disk/disk.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	keymanagerbase "github.com/spiffe/spire/pkg/server/plugin/keymanager/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,12 +35,12 @@ func asBuiltIn(p *KeyManager) catalog.BuiltIn {
 }
 
 type configuration struct {
-	KeysPath string `hcl:"keys_path"`
+	KeysPath string `hcl:"keys_path" yaml:"keysPath"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *configuration {
 	newConfig := new(configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
@@ -22,12 +22,12 @@ import (
 	"github.com/andres-erbsen/clock"
 	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
@@ -119,28 +119,28 @@ type Plugin struct {
 // Config provides configuration context for the plugin.
 type Config struct {
 	// File path location where information about generated keys will be persisted.
-	KeyIdentifierFile string `hcl:"key_identifier_file" json:"key_identifier_file"`
+	KeyIdentifierFile string `hcl:"key_identifier_file" json:"key_identifier_file" yaml:"keyIdentifierFile"`
 
 	// Key metadata used by the plugin.
-	KeyIdentifierValue string `hcl:"key_identifier_value" json:"key_identifier_value"`
+	KeyIdentifierValue string `hcl:"key_identifier_value" json:"key_identifier_value" yaml:"keyIdentifierValue"`
 
 	// File path location to a custom IAM Policy (v3) that will be set to
 	// created CryptoKeys.
-	KeyPolicyFile string `hcl:"key_policy_file" json:"key_policy_file"`
+	KeyPolicyFile string `hcl:"key_policy_file" json:"key_policy_file" yaml:"keyPolicyFile"`
 
 	// KeyRing is the resource ID of the key ring where the keys managed by this
 	// plugin reside, in the format projects/*/locations/*/keyRings/*.
-	KeyRing string `hcl:"key_ring" json:"key_ring"`
+	KeyRing string `hcl:"key_ring" json:"key_ring" yaml:"keyRing"`
 
 	// Path to the service account file used to authenticate with the Cloud KMS
 	// API. If not specified, the value of the GOOGLE_APPLICATION_CREDENTIALS
 	// environment variable is used.
-	ServiceAccountFile string `hcl:"service_account_file" json:"service_account_file"`
+	ServiceAccountFile string `hcl:"service_account_file" json:"service_account_file" yaml:"serviceAccountFile"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	newConfig := new(Config)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 	}
 

--- a/pkg/server/plugin/nodeattestor/awsiid/eks.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/eks.go
@@ -27,7 +27,7 @@ var (
 )
 
 type eksValidationConfig struct {
-	EKSClusterNames []string `hcl:"eks_cluster_names"`
+	EKSClusterNames []string `hcl:"eks_cluster_names" yaml:"eksClusterNames"`
 }
 
 type eksValidator struct {

--- a/pkg/server/plugin/nodeattestor/awsiid/iid.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid.go
@@ -30,7 +30,6 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/fullsailor/pkcs7"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -38,6 +37,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -119,22 +119,22 @@ type IIDAttestorPlugin struct {
 // IIDAttestorConfig holds hcl configuration for IID attestor plugin
 type IIDAttestorConfig struct {
 	SessionConfig                   `hcl:",squash"`
-	SkipBlockDevice                 bool                 `hcl:"skip_block_device"`
-	DisableInstanceProfileSelectors bool                 `hcl:"disable_instance_profile_selectors"`
-	LocalValidAcctIDs               []string             `hcl:"account_ids_for_local_validation"`
-	AgentPathTemplate               string               `hcl:"agent_path_template"`
-	AssumeRole                      string               `hcl:"assume_role"`
-	Partition                       string               `hcl:"partition"`
-	ValidateOrgAccountID            *orgValidationConfig `hcl:"verify_organization"`
-	ValidateEKSClusterMembership    *eksValidationConfig `hcl:"validate_eks_cluster_membership"`
+	SkipBlockDevice                 bool                 `hcl:"skip_block_device" yaml:"skipBlockDevice"`
+	DisableInstanceProfileSelectors bool                 `hcl:"disable_instance_profile_selectors" yaml:"disableInstanceProfileSelectors"`
+	LocalValidAcctIDs               []string             `hcl:"account_ids_for_local_validation" yaml:"accountIdsForLocalValidation"`
+	AgentPathTemplate               string               `hcl:"agent_path_template" yaml:"agentPathTemplate"`
+	AssumeRole                      string               `hcl:"assume_role" yaml:"assumeRole"`
+	Partition                       string               `hcl:"partition" yaml:"partition"`
+	ValidateOrgAccountID            *orgValidationConfig `hcl:"verify_organization" yaml:"verifyOrganization,omitempty"`
+	ValidateEKSClusterMembership    *eksValidationConfig `hcl:"validate_eks_cluster_membership" yaml:"validateEksClusterMembership,omitempty"`
 	pathTemplate                    *agentpathtemplate.Template
 	trustDomain                     spiffeid.TrustDomain
 	getAWSCACertificate             func(string, PublicKeyType) (*x509.Certificate, error)
 }
 
-func (p *IIDAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IIDAttestorConfig {
+func (p *IIDAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *IIDAttestorConfig {
 	newConfig := new(IIDAttestorConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -32,10 +32,10 @@ var (
 )
 
 type orgValidationConfig struct {
-	AccountID      string `hcl:"management_account_id"`
-	AccountRole    string `hcl:"assume_org_role"`
-	AccountRegion  string `hcl:"management_account_region"`
-	AccountListTTL string `hcl:"org_account_map_ttl"`
+	AccountID      string `hcl:"management_account_id" yaml:"managementAccountID"`
+	AccountRole    string `hcl:"assume_org_role" yaml:"assumeOrgRole"`
+	AccountRegion  string `hcl:"management_account_region" yaml:"managementAccountRegion"`
+	AccountListTTL string `hcl:"org_account_map_ttl" yaml:"orgAccountMapTTL"`
 }
 
 type orgValidator struct {

--- a/pkg/server/plugin/nodeattestor/awsiid/session.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/session.go
@@ -14,10 +14,10 @@ import (
 
 // SessionConfig is a common config for AWS session config.
 type SessionConfig struct {
-	AccessKeyID     string `hcl:"access_key_id"`
-	SecretAccessKey string `hcl:"secret_access_key"`
-	AssumeRole      string `hcl:"assume_role"`
-	Partition       string `hcl:"partition"`
+	AccessKeyID     string `hcl:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey string `hcl:"secret_access_key" yaml:"secretAccessKey"`
+	AssumeRole      string `hcl:"assume_role" yaml:"assumeRole"`
+	Partition       string `hcl:"partition" yaml:"partition"`
 }
 
 func (cfg *SessionConfig) Validate(defaultAccessKeyID, defaultSecretAccessKey string) error {

--- a/pkg/server/plugin/nodeattestor/azureimds/imds.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/imds.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,26 +40,26 @@ func builtin(p *IMDSAttestorPlugin) catalog.BuiltIn {
 }
 
 type SecretAuthConfig struct {
-	AppID     string `hcl:"app_id" json:"app_id"`
-	AppSecret string `hcl:"app_secret" json:"app_secret"`
+	AppID     string `hcl:"app_id" json:"app_id" yaml:"appID"`
+	AppSecret string `hcl:"app_secret" json:"app_secret" yaml:"appSecret"`
 }
 
 type TokenAuthConfig struct {
-	TokenPath string `hcl:"token_path" json:"token_path"`
-	AppID     string `hcl:"app_id" json:"app_id"`
+	TokenPath string `hcl:"token_path" json:"token_path" yaml:"tokenPath"`
+	AppID     string `hcl:"app_id" json:"app_id" yaml:"appID"`
 }
 
 type TenantConfig struct {
-	AuthType                string            `hcl:"auth_type" json:"auth_type"`
-	SecretAuth              *SecretAuthConfig `hcl:"secret_auth" json:"secret_auth"`
-	TokenAuth               *TokenAuthConfig  `hcl:"token_auth" json:"token_auth"`
-	AllowedTags             []string          `hcl:"allowed_vm_tags" json:"allowed_vm_tags"`
-	RestrictToSubscriptions []*string         `hcl:"restrict_to_subscriptions" json:"restrict_to_subscriptions"`
+	AuthType                string            `hcl:"auth_type" json:"auth_type" yaml:"authType"`
+	SecretAuth              *SecretAuthConfig `hcl:"secret_auth" json:"secret_auth" yaml:"secretAuth,omitempty"`
+	TokenAuth               *TokenAuthConfig  `hcl:"token_auth" json:"token_auth" yaml:"tokenAuth,omitempty"`
+	AllowedTags             []string          `hcl:"allowed_vm_tags" json:"allowed_vm_tags" yaml:"allowedVmTags"`
+	RestrictToSubscriptions []*string         `hcl:"restrict_to_subscriptions" json:"restrict_to_subscriptions" yaml:"restrictToSubscriptions"`
 }
 
 type IMDSAttestorConfig struct {
-	Tenants           map[string]*TenantConfig `hcl:"tenants" json:"tenants"`
-	AgentPathTemplate string                   `hcl:"agent_path_template" json:"agent_path_template"`
+	Tenants           map[string]*TenantConfig `hcl:"tenants" json:"tenants" yaml:"tenants"`
+	AgentPathTemplate string                   `hcl:"agent_path_template" json:"agent_path_template" yaml:"agentPathTemplate"`
 }
 
 type tenantConfig struct {
@@ -82,10 +82,10 @@ func (t *tenantConfig) subscriptionAllowed(subscriptionID string) bool {
 	return ok
 }
 
-func (p *IMDSAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *imdsAttestorConfig {
+func (p *IMDSAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *imdsAttestorConfig {
 	newConfig := new(IMDSAttestorConfig)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/azuremsi/msi.go
+++ b/pkg/server/plugin/nodeattestor/azuremsi/msi.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -27,6 +26,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/jwtutil"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -78,15 +78,15 @@ func builtin(p *MSIAttestorPlugin) catalog.BuiltIn {
 }
 
 type TenantConfig struct {
-	ResourceID     string `hcl:"resource_id" json:"resource_id"`
-	SubscriptionID string `hcl:"subscription_id" json:"subscription_id"`
-	AppID          string `hcl:"app_id" json:"app_id"`
-	AppSecret      string `hcl:"app_secret" json:"app_secret"`
+	ResourceID     string `hcl:"resource_id" json:"resource_id" yaml:"resourceID"`
+	SubscriptionID string `hcl:"subscription_id" json:"subscription_id" yaml:"subscriptionID"`
+	AppID          string `hcl:"app_id" json:"app_id" yaml:"appID"`
+	AppSecret      string `hcl:"app_secret" json:"app_secret" yaml:"appSecret"`
 }
 
 type MSIAttestorConfig struct {
-	Tenants           map[string]*TenantConfig `hcl:"tenants" json:"tenants"`
-	AgentPathTemplate string                   `hcl:"agent_path_template" json:"agent_path_template"`
+	Tenants           map[string]*TenantConfig `hcl:"tenants" json:"tenants" yaml:"tenants"`
+	AgentPathTemplate string                   `hcl:"agent_path_template" json:"agent_path_template" yaml:"agentPathTemplate"`
 }
 
 type tenantConfig struct {
@@ -100,10 +100,10 @@ type msiAttestorConfig struct {
 	idPathTemplate *agentpathtemplate.Template
 }
 
-func (p *MSIAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *msiAttestorConfig {
+func (p *MSIAttestorPlugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *msiAttestorConfig {
 	newConfig := new(MSIAttestorConfig)
 
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/hcl"
-
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	hclog "github.com/hashicorp/go-hclog"
@@ -20,6 +18,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
@@ -77,18 +76,18 @@ type IITAttestorConfig struct {
 	allowedLabelKeys    map[string]bool
 	allowedMetadataKeys map[string]bool
 
-	ProjectIDAllowList   []string `hcl:"projectid_allow_list"`
-	AgentPathTemplate    string   `hcl:"agent_path_template"`
-	UseInstanceMetadata  bool     `hcl:"use_instance_metadata"`
-	AllowedLabelKeys     []string `hcl:"allowed_label_keys"`
-	AllowedMetadataKeys  []string `hcl:"allowed_metadata_keys"`
-	MaxMetadataValueSize int      `hcl:"max_metadata_value_size"`
-	ServiceAccountFile   string   `hcl:"service_account_file"`
+	ProjectIDAllowList   []string `hcl:"projectid_allow_list" yaml:"projectidAllowList"`
+	AgentPathTemplate    string   `hcl:"agent_path_template" yaml:"agentPathTemplate"`
+	UseInstanceMetadata  bool     `hcl:"use_instance_metadata" yaml:"useInstanceMetadata"`
+	AllowedLabelKeys     []string `hcl:"allowed_label_keys" yaml:"allowedLabelKeys"`
+	AllowedMetadataKeys  []string `hcl:"allowed_metadata_keys" yaml:"allowedMetadataKeys"`
+	MaxMetadataValueSize int      `hcl:"max_metadata_value_size" yaml:"maxMetadataValueSize"`
+	ServiceAccountFile   string   `hcl:"service_account_file" yaml:"serviceAccountFile"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IITAttestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *IITAttestorConfig {
 	newConfig := new(IITAttestorConfig)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/httpchallenge"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -61,9 +61,9 @@ type configuration struct {
 	tofu              bool
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *configuration {
 	hclConfig := new(Config)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}
@@ -115,10 +115,10 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 }
 
 type Config struct {
-	AllowedDNSPatterns []string `hcl:"allowed_dns_patterns"`
-	RequiredPort       *int     `hcl:"required_port"`
-	AllowNonRootPorts  *bool    `hcl:"allow_non_root_ports"`
-	TOFU               *bool    `hcl:"tofu"`
+	AllowedDNSPatterns []string `hcl:"allowed_dns_patterns" yaml:"allowedDNSPatterns"`
+	RequiredPort       *int     `hcl:"required_port" yaml:"requiredPort"`
+	AllowNonRootPorts  *bool    `hcl:"allow_non_root_ports" yaml:"allowNonRootPorts"`
+	TOFU               *bool    `hcl:"tofu" yaml:"tofu"`
 }
 
 type Plugin struct {

--- a/pkg/server/plugin/nodeattestor/jointoken/join_token.go
+++ b/pkg/server/plugin/nodeattestor/jointoken/join_token.go
@@ -3,12 +3,12 @@ package jointoken
 import (
 	"context"
 
-	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/token"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -29,12 +29,12 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Configuration struct {
-	Extra map[string][]token.Pos `hcl:",unusedKeyPositions"`
+	Extra map[string][]token.Pos `hcl:",unusedKeyPositions" yaml:"-"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/k8spsat/psat.go
+++ b/pkg/server/plugin/nodeattestor/k8spsat/psat.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s/apiserver"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -42,29 +42,29 @@ func builtin(p *AttestorPlugin) catalog.BuiltIn {
 
 // AttestorConfig contains a map of clusters that uses cluster name as key
 type AttestorConfig struct {
-	Clusters map[string]*ClusterConfig `hcl:"clusters"`
+	Clusters map[string]*ClusterConfig `hcl:"clusters" yaml:"clusters"`
 }
 
 // ClusterConfig holds a single cluster configuration
 type ClusterConfig struct {
 	// Array of allowed service accounts names
 	// Attestation is denied if coming from a service account that is not in the list
-	ServiceAccountAllowList []string `hcl:"service_account_allow_list"`
+	ServiceAccountAllowList []string `hcl:"service_account_allow_list" yaml:"serviceAccountAllowList"`
 
 	// Audience for PSAT token validation
 	// If audience is not configured, defaultAudience will be used
 	// If audience value is set to an empty slice, k8s apiserver audience will be used
-	Audience *[]string `hcl:"audience"`
+	Audience *[]string `hcl:"audience" yaml:"audience,omitempty"`
 
 	// Kubernetes configuration file path
 	// Used to create a k8s client to query the API server. If string is empty, in-cluster configuration is used
-	KubeConfigFile string `hcl:"kube_config_file"`
+	KubeConfigFile string `hcl:"kube_config_file" yaml:"kubeConfigFile"`
 
 	// Node labels that are allowed to use as selectors
-	AllowedNodeLabelKeys []string `hcl:"allowed_node_label_keys"`
+	AllowedNodeLabelKeys []string `hcl:"allowed_node_label_keys" yaml:"allowedNodeLabelKeys"`
 
 	// Pod labels that are allowed to use as selectors
-	AllowedPodLabelKeys []string `hcl:"allowed_pod_label_keys"`
+	AllowedPodLabelKeys []string `hcl:"allowed_pod_label_keys" yaml:"allowedPodLabelKeys"`
 }
 
 type attestorConfig struct {
@@ -80,9 +80,9 @@ type clusterConfig struct {
 	allowedPodLabelKeys  map[string]bool
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *attestorConfig {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *attestorConfig {
 	hclConfig := new(AttestorConfig)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/tpmdevid/devid.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/devid.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/google/go-tpm/legacy/tpm2"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -20,6 +19,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/idutil"
 	common_devid "github.com/spiffe/spire/pkg/common/plugin/tpmdevid"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,8 +41,8 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Config struct {
-	DevIDBundlePath       string `hcl:"devid_ca_path"`
-	EndorsementBundlePath string `hcl:"endorsement_ca_path"`
+	DevIDBundlePath       string `hcl:"devid_ca_path" yaml:"devIDBundlePath"`
+	EndorsementBundlePath string `hcl:"endorsement_ca_path" yaml:"endorsementBundlePath"`
 }
 
 type config struct {
@@ -52,9 +52,9 @@ type config struct {
 	ekRoots    *x509.CertPool
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *config {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *config {
 	hclConfig := new(Config)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	identityproviderv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/identityprovider/v1"
@@ -22,6 +21,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,13 +47,13 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Config struct {
-	Mode              string   `hcl:"mode"`
-	SVIDPrefix        *string  `hcl:"spiffe_prefix"`
-	CABundlePath      string   `hcl:"ca_bundle_path"`
-	CABundlePaths     []string `hcl:"ca_bundle_paths"`
-	AgentPathTemplate string   `hcl:"agent_path_template"`
-	MaxIntermediates  *int     `hcl:"max_intermediates"`
-	MaxRSAKeySize     *int     `hcl:"max_rsa_key_size"`
+	Mode              string   `hcl:"mode" yaml:"mode"`
+	SVIDPrefix        *string  `hcl:"spiffe_prefix" yaml:"spiffePrefix"`
+	CABundlePath      string   `hcl:"ca_bundle_path" yaml:"caBundlePath"`
+	CABundlePaths     []string `hcl:"ca_bundle_paths" yaml:"caBundlePaths"`
+	AgentPathTemplate string   `hcl:"agent_path_template" yaml:"agentPathTemplate"`
+	MaxIntermediates  *int     `hcl:"max_intermediates" yaml:"maxIntermediates"`
+	MaxRSAKeySize     *int     `hcl:"max_rsa_key_size" yaml:"maxRSAKeySize"`
 }
 
 type configuration struct {
@@ -66,9 +66,9 @@ type configuration struct {
 	maxRSAKeySize    int
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *configuration {
 	hclConfig := new(Config)
-	if err := hcl.Decode(hclConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, hclConfig); err != nil {
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle.go
@@ -10,7 +10,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	identityproviderv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/identityprovider/v1"
 	notifierv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/notifier/v1"
@@ -18,6 +17,7 @@ import (
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -43,14 +43,14 @@ type bucketClient interface {
 }
 
 type configuration struct {
-	Bucket             string `hcl:"bucket"`
-	ObjectPath         string `hcl:"object_path"`
-	ServiceAccountFile string `hcl:"service_account_file"`
+	Bucket             string `hcl:"bucket" yaml:"bucket"`
+	ObjectPath         string `hcl:"object_path" yaml:"objectPath"`
+	ServiceAccountFile string `hcl:"service_account_file" yaml:"serviceAccountFile"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *configuration {
 	newConfig := new(configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportErrorf("plugin configuration is malformed: %s", err)
 		return nil
 	}

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	identityproviderv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/identityprovider/v1"
 	notifierv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/notifier/v1"
@@ -19,6 +18,7 @@ import (
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -56,12 +56,12 @@ func builtIn(p *Plugin) catalog.BuiltIn {
 }
 
 type cluster struct {
-	Namespace          string `hcl:"namespace"`
-	ConfigMap          string `hcl:"config_map"`
-	ConfigMapKey       string `hcl:"config_map_key"`
-	WebhookLabel       string `hcl:"webhook_label"`
-	APIServiceLabel    string `hcl:"api_service_label"`
-	KubeConfigFilePath string `hcl:"kube_config_file_path"`
+	Namespace          string `hcl:"namespace" yaml:"namespace"`
+	ConfigMap          string `hcl:"config_map" yaml:"configMap"`
+	ConfigMapKey       string `hcl:"config_map_key" yaml:"configMapKey"`
+	WebhookLabel       string `hcl:"webhook_label" yaml:"webhookLabel"`
+	APIServiceLabel    string `hcl:"api_service_label" yaml:"apiServiceLabel"`
+	KubeConfigFilePath string `hcl:"kube_config_file_path" yaml:"kubeConfigFilePath"`
 }
 
 type Configuration struct {
@@ -69,9 +69,9 @@ type Configuration struct {
 	Clusters []cluster       `hcl:"clusters"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/awspca/pca.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca.go
@@ -13,13 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -53,18 +53,18 @@ func builtin(p *PCAPlugin) catalog.BuiltIn {
 
 // Configuration provides configuration context for the plugin
 type Configuration struct {
-	Region                  string `hcl:"region" json:"region"`
-	Endpoint                string `hcl:"endpoint" json:"endpoint"`
-	CertificateAuthorityARN string `hcl:"certificate_authority_arn" json:"certificate_authority_arn"`
-	SigningAlgorithm        string `hcl:"signing_algorithm" json:"signing_algorithm"`
-	CASigningTemplateARN    string `hcl:"ca_signing_template_arn" json:"ca_signing_template_arn"`
-	AssumeRoleARN           string `hcl:"assume_role_arn" json:"assume_role_arn"`
-	SupplementalBundlePath  string `hcl:"supplemental_bundle_path" json:"supplemental_bundle_path"`
+	Region                  string `hcl:"region" json:"region" yaml:"region"`
+	Endpoint                string `hcl:"endpoint" json:"endpoint" yaml:"endpoint"`
+	CertificateAuthorityARN string `hcl:"certificate_authority_arn" json:"certificate_authority_arn" yaml:"certificateAuthorityARN"`
+	SigningAlgorithm        string `hcl:"signing_algorithm" json:"signing_algorithm" yaml:"signingAlgorithm"`
+	CASigningTemplateARN    string `hcl:"ca_signing_template_arn" json:"ca_signing_template_arn" yaml:"caSigningTemplateARN"`
+	AssumeRoleARN           string `hcl:"assume_role_arn" json:"assume_role_arn" yaml:"assumeRoleARN"`
+	SupplementalBundlePath  string `hcl:"supplemental_bundle_path" json:"supplemental_bundle_path" yaml:"supplementalBundlePath"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/awssecret/awssecret.go
+++ b/pkg/server/plugin/upstreamauthority/awssecret/awssecret.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -17,6 +16,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/x509svid"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"google.golang.org/grpc/codes"
@@ -43,19 +43,19 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Configuration struct {
-	Region          string `hcl:"region" json:"region"`
-	CertFileARN     string `hcl:"cert_file_arn" json:"cert_file_arn"`
-	KeyFileARN      string `hcl:"key_file_arn" json:"key_file_arn"`
-	BundleFileARN   string `hcl:"bundle_file_arn" json:"bundle_file_arn"`
-	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id"`
-	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key"`
-	SecurityToken   string `hcl:"secret_token" json:"secret_token"`
-	AssumeRoleARN   string `hcl:"assume_role_arn" json:"assume_role_arn"`
+	Region          string `hcl:"region" json:"region" yaml:"region"`
+	CertFileARN     string `hcl:"cert_file_arn" json:"cert_file_arn" yaml:"certFileARN"`
+	KeyFileARN      string `hcl:"key_file_arn" json:"key_file_arn" yaml:"keyFileARN"`
+	BundleFileARN   string `hcl:"bundle_file_arn" json:"bundle_file_arn" yaml:"bundleFileARN"`
+	AccessKeyID     string `hcl:"access_key_id" json:"access_key_id" yaml:"accessKeyID"`
+	SecretAccessKey string `hcl:"secret_access_key" json:"secret_access_key" yaml:"secretAccessKey"`
+	SecurityToken   string `hcl:"secret_token" json:"secret_token" yaml:"securityToken"`
+	AssumeRoleARN   string `hcl:"assume_role_arn" json:"assume_role_arn" yaml:"assumeRoleARN"`
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/certmanager/certmanager.go
+++ b/pkg/server/plugin/upstreamauthority/certmanager/certmanager.go
@@ -6,13 +6,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	cmapi "github.com/spiffe/spire/pkg/server/plugin/upstreamauthority/certmanager/internal/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,18 +40,18 @@ func builtin(p *Plugin) catalog.BuiltIn {
 type Configuration struct {
 	// Options which are used for configuring the target issuer to sign requests.
 	// The CertificateRequest will be created in the configured namespace.
-	IssuerName  string `hcl:"issuer_name" json:"issuer_name"`
-	IssuerKind  string `hcl:"issuer_kind" json:"issuer_kind"`
-	IssuerGroup string `hcl:"issuer_group" json:"issuer_group"`
-	Namespace   string `hcl:"namespace" json:"namespace"`
+	IssuerName  string `hcl:"issuer_name" json:"issuer_name" yaml:"issuerName"`
+	IssuerKind  string `hcl:"issuer_kind" json:"issuer_kind" yaml:"issuerKind"`
+	IssuerGroup string `hcl:"issuer_group" json:"issuer_group" yaml:"issuerGroup"`
+	Namespace   string `hcl:"namespace" json:"namespace" yaml:"namespace"`
 
 	// File path to the kubeconfig used to build the generic Kubernetes client.
-	KubeConfigFilePath string `hcl:"kube_config_file" json:"kube_config_file"`
+	KubeConfigFilePath string `hcl:"kube_config_file" json:"kube_config_file" yaml:"kubeConfigFilePath"`
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/disk/disk.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,6 +19,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/x509svid"
 	"github.com/spiffe/spire/pkg/common/x509util"
 )
@@ -44,14 +44,14 @@ func builtin(p *Plugin) catalog.BuiltIn {
 type Configuration struct {
 	trustDomain spiffeid.TrustDomain
 
-	CertFilePath   string `hcl:"cert_file_path" json:"cert_file_path"`
-	KeyFilePath    string `hcl:"key_file_path" json:"key_file_path"`
-	BundleFilePath string `hcl:"bundle_file_path" json:"bundle_file_path"`
+	CertFilePath   string `hcl:"cert_file_path" json:"cert_file_path" yaml:"certFilePath"`
+	KeyFilePath    string `hcl:"key_file_path" json:"key_file_path" yaml:"keyFilePath"`
+	BundleFilePath string `hcl:"bundle_file_path" json:"bundle_file_path" yaml:"bundleFilePath"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/ejbca/ejbca.go
+++ b/pkg/server/plugin/upstreamauthority/ejbca/ejbca.go
@@ -14,13 +14,13 @@ import (
 
 	ejbcaclient "github.com/Keyfactor/ejbca-go-client-sdk/api/ejbca"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -75,23 +75,23 @@ func builtin(p *Plugin) catalog.BuiltIn {
 
 // Config defines the configuration for the plugin.
 type Config struct {
-	Hostname               string `hcl:"hostname" json:"hostname"`
-	CaCertPath             string `hcl:"ca_cert_path" json:"ca_cert_path"`
-	ClientCertPath         string `hcl:"client_cert_path" json:"client_cert_path"`
-	ClientCertKeyPath      string `hcl:"client_cert_key_path" json:"client_cert_key_path"`
-	CAName                 string `hcl:"ca_name" json:"ca_name"`
-	EndEntityProfileName   string `hcl:"end_entity_profile_name" json:"end_entity_profile_name"`
-	CertificateProfileName string `hcl:"certificate_profile_name" json:"certificate_profile_name"`
-	DefaultEndEntityName   string `hcl:"end_entity_name" json:"end_entity_name"`
-	AccountBindingID       string `hcl:"account_binding_id" json:"account_binding_id"`
+	Hostname               string `hcl:"hostname" json:"hostname" yaml:"hostname"`
+	CaCertPath             string `hcl:"ca_cert_path" json:"ca_cert_path" yaml:"caCertPath"`
+	ClientCertPath         string `hcl:"client_cert_path" json:"client_cert_path" yaml:"clientCertPath"`
+	ClientCertKeyPath      string `hcl:"client_cert_key_path" json:"client_cert_key_path" yaml:"clientCertKeyPath"`
+	CAName                 string `hcl:"ca_name" json:"ca_name" yaml:"caName"`
+	EndEntityProfileName   string `hcl:"end_entity_profile_name" json:"end_entity_profile_name" yaml:"endEntityProfileName"`
+	CertificateProfileName string `hcl:"certificate_profile_name" json:"certificate_profile_name" yaml:"certificateProfileName"`
+	DefaultEndEntityName   string `hcl:"end_entity_name" json:"end_entity_name" yaml:"endEntityName"`
+	AccountBindingID       string `hcl:"account_binding_id" json:"account_binding_id" yaml:"accountBindingID"`
 }
 
-func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
+func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Config {
 	logger := p.logger.Named("parseConfig")
 	logger.Debug("Decoding EJBCA configuration")
 
 	newConfig := &Config{}
-	if err := hcl.Decode(&newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, &newConfig); err != nil {
 		status.ReportErrorf("failed to decode configuration: %v", err)
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
+++ b/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
@@ -17,7 +17,6 @@ import (
 	privateca "cloud.google.com/go/security/privateca/apiv1"
 	"cloud.google.com/go/security/privateca/apiv1/privatecapb"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
@@ -25,6 +24,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
@@ -51,11 +51,11 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type CertificateAuthoritySpec struct {
-	Project    string `hcl:"project_name"`
-	Location   string `hcl:"region_name"`
-	CaPool     string `hcl:"ca_pool"`
-	LabelKey   string `hcl:"label_key"`
-	LabelValue string `hcl:"label_value"`
+	Project    string `hcl:"project_name" yaml:"projectName"`
+	Location   string `hcl:"region_name" yaml:"regionName"`
+	CaPool     string `hcl:"ca_pool" yaml:"caPool"`
+	LabelKey   string `hcl:"label_key" yaml:"labelKey"`
+	LabelValue string `hcl:"label_value" yaml:"labelValue"`
 }
 
 func (spec *CertificateAuthoritySpec) caParentPath(caPool string) string {
@@ -67,12 +67,12 @@ func (spec *CertificateAuthoritySpec) caPoolParentPath() string {
 }
 
 type Configuration struct {
-	RootSpec CertificateAuthoritySpec `hcl:"root_cert_spec,block"`
+	RootSpec CertificateAuthoritySpec `hcl:"root_cert_spec,block" yaml:"rootCertSpec"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/spire/spire.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
@@ -20,6 +19,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/common/tlspolicy"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -33,15 +33,15 @@ const (
 )
 
 type Configuration struct {
-	ServerAddr        string             `hcl:"server_address" json:"server_address"`
-	ServerPort        string             `hcl:"server_port" json:"server_port"`
-	WorkloadAPISocket string             `hcl:"workload_api_socket" json:"workload_api_socket"`
-	Experimental      experimentalConfig `hcl:"experimental"`
+	ServerAddr        string             `hcl:"server_address" json:"server_address" yaml:"serverAddress"`
+	ServerPort        string             `hcl:"server_port" json:"server_port" yaml:"serverPort"`
+	WorkloadAPISocket string             `hcl:"workload_api_socket" json:"workload_api_socket" yaml:"workloadAPISocket"`
+	Experimental      experimentalConfig `hcl:"experimental" yaml:"experimental"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/pkg/server/plugin/upstreamauthority/vault/vault.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/hcl"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/common/plugindecode"
 	"github.com/spiffe/spire/pkg/server/common/vault"
 )
 
@@ -40,15 +40,15 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type Configuration struct {
-	vault.BaseConfiguration `hcl:",squash"`
+	vault.BaseConfiguration `hcl:",squash" yaml:",inline"`
 
 	// Name of the mount point where PKI secret engine is mounted. (e.g., /<mount_point>/ca/pem)
 	PKIMountPoint string `hcl:"pki_mount_point" json:"pki_mount_point"`
 }
 
-func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
+func buildConfig(coreConfig catalog.CoreConfig, text string, format catalog.ConfigFormat, status *pluginconf.Status) *Configuration {
 	newConfig := new(Configuration)
-	if err := hcl.Decode(newConfig, hclText); err != nil {
+	if err := plugindecode.DecodeConfig(text, format, newConfig); err != nil {
 		status.ReportError("plugin configuration is malformed")
 		return nil
 	}

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/datastore"
 	sql "github.com/spiffe/spire/pkg/server/datastore/sqlstore"
@@ -44,7 +45,7 @@ func New(tb testing.TB) *DataStore {
 	err := ds.Configure(ctx, fmt.Sprintf(`
 		database_type = "sqlite3"
 		connection_string = "file:%s"
-	`, dbPath))
+	`, dbPath), catalog.ConfigFormatHCL)
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {

--- a/test/fixture/config/agent_good_posix.yaml
+++ b/test/fixture/config/agent_good_posix.yaml
@@ -1,0 +1,34 @@
+agent:
+  bindAddress: "127.0.0.1"
+  bindPort: 8088
+  dataDir: "."
+  logLevel: "INFO"
+  serverAddress: "127.0.0.1"
+  serverPort: 8081
+  socketPath: "/tmp/spire-agent/public/api.sock"
+  trustBundlePath: "conf/agent/dummy_root_ca.crt"
+  trustDomain: "example.org"
+  allowUnauthenticatedVerifiers: true
+  allowedForeignJwtClaims:
+    - "c1"
+    - "c2"
+    - "c3"
+
+plugins:
+  plugin_type_agent:
+    plugin_name_agent:
+      pluginCmd: "./pluginAgentCmd"
+      pluginChecksum: "pluginAgentChecksum"
+      pluginData:
+        joinToken: "PLUGIN-AGENT-NOT-A-SECRET"
+    plugin_disabled:
+      pluginCmd: "./pluginAgentCmd"
+      enabled: false
+      pluginChecksum: "pluginAgentChecksum"
+      pluginData:
+        joinToken: "PLUGIN-AGENT-NOT-A-SECRET"
+    plugin_enabled:
+      pluginCmd: "./pluginAgentCmd"
+      enabled: true
+      pluginChecksum: "pluginAgentChecksum"
+      pluginDataFile: "plugin.conf"

--- a/test/fixture/config/server_good_posix.yaml
+++ b/test/fixture/config/server_good_posix.yaml
@@ -1,0 +1,55 @@
+server:
+  bindAddress: "127.0.0.1"
+  bindPort: 8081
+  socketPath: "/tmp/spire-server/private/api-test.sock"
+  trustDomain: "example.org"
+  logLevel: "INFO"
+  auditLogEnabled: true
+  proxyProtocolTrustedCidrs:
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+  federation:
+    bundleEndpoint:
+      address: "0.0.0.0"
+      port: 8443
+      acme:
+        domainName: "example.org"
+    federatesWith:
+      "domain1.test":
+        bundleEndpoint:
+          address: "1.2.3.4"
+          useWebPki: true
+      "domain2.test":
+        bundleEndpoint:
+          address: "5.6.7.8"
+          spiffeId: "spiffe://domain2.test/bundle-provider"
+      "domain3.test":
+        bundleEndpointUrl: "https://9.10.11.12:8443"
+        bundleEndpointProfile:
+          httpsSpiffe:
+            endpointSpiffeId: "spiffe://different-domain.test/my-spiffe-bundle-endpoint-server"
+      "domain4.test":
+        bundleEndpointUrl: "https://13.14.15.16:8444"
+        bundleEndpointProfile:
+          httpsWeb: {}
+  experimental:
+    requirePqKem: true
+
+plugins:
+  plugin_type_server:
+    plugin_name_server:
+      pluginCmd: "./pluginServerCmd"
+      pluginChecksum: "pluginServerChecksum"
+      pluginData:
+        joinToken: "PLUGIN-SERVER-NOT-A-SECRET"
+    plugin_disabled:
+      pluginCmd: "./pluginServerCmd"
+      enabled: false
+      pluginChecksum: "pluginServerChecksum"
+      pluginData:
+        joinToken: "PLUGIN-SERVER-NOT-A-SECRET"
+    plugin_enabled:
+      pluginCmd: "./pluginServerCmd"
+      enabled: true
+      pluginChecksum: "pluginServerChecksum"
+      pluginDataFile: "plugin.conf"

--- a/test/plugintest/load.go
+++ b/test/plugintest/load.go
@@ -52,7 +52,7 @@ func Load(t *testing.T, builtIn catalog.BuiltIn, pluginFacade catalog.Facade, op
 	require.NoError(t, err)
 
 	if conf.doConfigure {
-		err := configurer.Configure(context.Background(), conf.coreConfig, conf.makeConfigData(t))
+		err := configurer.Configure(context.Background(), conf.coreConfig, conf.makeConfigData(t), catalog.ConfigFormatHCL)
 		if conf.configureErr != nil {
 			*conf.configureErr = err
 		} else {


### PR DESCRIPTION
**Changes**
- Adds experimental YAML as an optional configuration format for SPIRE server and agent, detected by file extension  (.yaml/.yml). HCL behavior is completely unchanged.
- Introduces pkg/common/plugindecode.DecodeConfig as a format-aware decode helper used by all built-in plugins.
- Updates DataSource to carry ConfigFormat alongside config text
- Update plugins.

**Notes**
- Experimental: A warning is logged when a YAML config file is loaded.
- spire-plugin-sdk dependency: This PR requires a companion PR to spire-plugin-sdk to be merged.
- No changes to existing HCL parsing — all current config files continue to work without modification.